### PR TITLE
refactor: dbatools v4.1.0 — modernize all collection scripts

### DIFF
--- a/CentralDB-Ops-Runbook.md
+++ b/CentralDB-Ops-Runbook.md
@@ -1,0 +1,591 @@
+# CentralDB Operations Runbook
+
+Step-by-step guide for deploying, configuring, scheduling, and troubleshooting the CentralDB v4 collection scripts.
+
+## Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [First-Time Deployment](#2-first-time-deployment)
+3. [SQL Agent Job Configuration](#3-sql-agent-job-configuration)
+4. [Recommended Schedule](#4-recommended-schedule)
+5. [Adding a New Instance](#5-adding-a-new-instance)
+6. [Removing an Instance](#6-removing-an-instance)
+7. [Upgrading dbatools](#7-upgrading-dbatools)
+8. [Troubleshooting](#8-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+### CentralDB server
+
+| Requirement | Detail |
+|-------------|--------|
+| SQL Server | 2016+ recommended, 2012+ minimum |
+| Database | `CentralDB` created from `CreateScript-NewCentralDB-Database.sql` |
+| Service account | Domain account used as SQL Agent proxy (e.g. `DOMAIN\svc_dba_automation`) |
+
+### Each collection server (SQL Agent host)
+
+| Requirement | Detail |
+|-------------|--------|
+| PowerShell | 5.1 (Windows PowerShell — not PowerShell Core / `pwsh`) |
+| dbatools | >= 2.0.0, installed with `-Scope AllUsers` |
+| Script share | UNC path readable by the SQL Agent proxy account |
+| Output path | Local directory writable by the SQL Agent proxy account |
+| Network | Proxy account must be able to connect to CentralDB and all target instances |
+
+Install dbatools on every server that runs collection jobs:
+
+```powershell
+Install-Module dbatools -Scope AllUsers -MinimumVersion 2.0.0
+```
+
+Verify the installed version:
+
+```powershell
+Get-Module dbatools -ListAvailable | Select-Object Name, Version
+```
+
+---
+
+## 2. First-Time Deployment
+
+### Step 1 — Create the CentralDB database
+
+In SSMS with SQLCMD mode enabled, run against your central SQL Server:
+
+```sql
+:r CreateScript-NewCentralDB-Database.sql
+```
+
+### Step 2 — Deploy stored procedures
+
+Run the following against the `CentralDB` database. These procedures are used by all collection scripts for instance discovery, run tracking, and baseline data collection:
+
+```sql
+-- Instance discovery (reads [Svr].[ServerList])
+:r SQL\StoredProcedures\Svr.usp_GetCollectionTargets.sql
+
+-- Run timestamp recording (updates [Svr].[ServerList])
+:r SQL\StoredProcedures\Svr.usp_SetCollectionLastRun.sql
+
+-- SQL performance counter baseline (two-snapshot DMV PIVOT)
+:r SQL\StoredProcedures\Inst.usp_GetBaselineStats.sql
+```
+
+### Step 3 — Verify ServerList schema
+
+The v4 scripts write to columns that may not exist in databases upgraded from earlier versions. Run against `CentralDB` and add any missing columns:
+
+```sql
+-- Check whether the tracking columns exist
+SELECT COLUMN_NAME
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA = 'Svr'
+  AND TABLE_NAME   = 'ServerList'
+  AND COLUMN_NAME IN ('WaitStatLastExecDate','BaselineLastExecDate',
+                      'InventoryLastExecDate','LastLoadGUID','LastUpdated');
+
+-- Add missing columns if needed
+ALTER TABLE [Svr].[ServerList]
+    ADD WaitStatLastExecDate  DATETIME2 NULL,
+        BaselineLastExecDate  DATETIME2 NULL,
+        InventoryLastExecDate DATETIME2 NULL,
+        LastLoadGUID          NVARCHAR(36)  NULL,
+        LastUpdated           DATETIME2 NULL;
+```
+
+### Step 4 — Register target instances
+
+```sql
+INSERT INTO [Svr].[ServerList] (ServerName, InstanceName, Active, Baseline)
+VALUES
+    ('SQL-PROD-01', 'MSSQLSERVER', 1, 1),
+    ('SQL-PROD-02', 'MSSQLSERVER', 1, 1),
+    ('SQL-PROD-03', 'INST1',       1, 1);
+```
+
+| Column | Effect |
+|--------|--------|
+| `Active = 1` | Included in Inventory collection |
+| `Baseline = 1` | Included in WaitStats and BaselineStats collections |
+
+### Step 5 — Copy scripts to a network share
+
+Place the `Collect\` folder on a UNC share accessible by all SQL Agent proxy accounts:
+
+```
+\\FILESERVER\DBATools\CentralDB\Collect\
+```
+
+Verify the proxy account can read the scripts:
+
+```powershell
+# Run as the proxy account (or use PsExec / runas)
+Get-ChildItem \\FILESERVER\DBATools\CentralDB\Collect\
+```
+
+### Step 6 — Create the SQL Agent proxy
+
+1. In SSMS, expand **Security > Credentials**. Create a new credential for the domain service account (`DOMAIN\svc_dba_automation`).
+2. Expand **SQL Server Agent > Proxies > CmdExec**. Create proxy `DBA_Automation_Proxy` using that credential.
+3. Grant the proxy to the operators/logins that own the collection jobs.
+
+### Step 7 — Verify end-to-end connectivity
+
+Run a test collection manually before creating SQL Agent jobs:
+
+```powershell
+.\Collect\Get-CentralWaitStats.ps1 `
+    -SqlInstance 'SQL-PROD-01' `
+    -CMSInstanceName 'CMS-01' `
+    -CMSDatabaseName 'CentralDB' `
+    -OutputPath 'C:\Temp\CentralDB' `
+    -Verbose
+```
+
+Confirm data arrived:
+
+```sql
+SELECT TOP 10 * FROM [Inst].[WaitStats]
+WHERE ServerName = 'SQL-PROD-01'
+ORDER BY CollectedAt DESC;
+```
+
+---
+
+## 3. SQL Agent Job Configuration
+
+### Step type
+
+Always use **CmdExec** — never the "PowerShell" step type. PowerShell steps do not return correct exit codes to SQL Agent, so failed runs may be reported as success.
+
+### Run As
+
+Set every job step to run as `DBA_Automation_Proxy`.
+
+### Command template
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "\\FILESERVER\DBATools\CentralDB\Collect\<script>.ps1" [parameters]
+```
+
+- `-NoProfile` — faster startup, no profile interference
+- `-NonInteractive` — prevents hangs on prompts
+- `-ExecutionPolicy Bypass` — avoids policy blocks without changing system policy
+- Do not use `Set-ExecutionPolicy` inside scripts
+
+### Per-script commands
+
+#### Get-CentralInventory
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Get-CentralInventory.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -Sections All
+  -RunLocally
+  -IntroduceDelay Y
+```
+
+To collect only specific sections (faster, useful for incremental refreshes):
+```
+  -Sections Instance,Databases
+```
+
+#### Get-CentralWaitStats
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Get-CentralWaitStats.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+```
+
+#### Get-CentralBaselineStats
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Get-CentralBaselineStats.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+```
+
+#### Invoke-CentralBlitzCollection
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Invoke-CentralBlitzCollection.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+  -DeployFRK N
+```
+
+To install/update First Responder Kit on first run: change `-DeployFRK N` to `-DeployFRK Y`, run once, then revert to `N`.
+
+#### Invoke-CentralBackup — FULL
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Invoke-CentralBackup.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+  -BackupType FULL
+  -Databases ALL_DATABASES
+  -Directory "\\BACKUPSERVER\Backups"
+  -Compress Y
+  -Verify Y
+  -CleanupTime 72
+  -DeployOla N
+```
+
+#### Invoke-CentralBackup — DIFF
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Invoke-CentralBackup.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+  -BackupType DIFF
+  -Databases USER_DATABASES
+  -Directory "\\BACKUPSERVER\Backups"
+  -Compress Y
+  -CleanupTime 48
+  -DeployOla N
+```
+
+#### Invoke-CentralBackup — LOG
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Invoke-CentralBackup.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+  -BackupType LOG
+  -Databases ALL_DATABASES
+  -Directory "\\BACKUPSERVER\Backups"
+  -Compress Y
+  -CleanupTime 48
+  -DeployOla N
+```
+
+#### Invoke-CentralIndexOptimize
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Invoke-CentralIndexOptimize.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+  -Databases USER_DATABASES
+  -FragmentationLevel1 5
+  -FragmentationLevel2 30
+  -SortInTempdb Y
+  -TimeLimit 14400
+  -DeployOla N
+```
+
+Remove `-TimeLimit` if you want unconstrained maintenance windows.
+
+#### Invoke-CentralIntegrityCheck
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Invoke-CentralIntegrityCheck.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -OutputPath "D:\Logs\CentralDB"
+  -RunLocally
+  -IntroduceDelay Y
+  -Databases ALL_DATABASES
+  -CheckCommands CHECKDB
+  -PhysicalOnly Y
+  -LockTimeout 10800
+  -TimeLimit 14400
+  -DeployOla N
+```
+
+### MSX/TSX variant (multi-server jobs)
+
+Replace `-RunLocally` with `-SqlInstance "$(ESCAPE_DQUOTE(SRVR))"` when enrolling instances as MSX targets:
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+  -File "\\FILESERVER\DBATools\CentralDB\Collect\Get-CentralWaitStats.ps1"
+  -CMSInstanceName "CMS-01"
+  -CMSDatabaseName "CentralDB"
+  -SqlInstance "$(ESCAPE_DQUOTE(SRVR))"
+  -OutputPath "D:\Logs\CentralDB"
+  -IntroduceDelay Y
+```
+
+---
+
+## 4. Recommended Schedule
+
+| Job | Frequency | Notes |
+|-----|-----------|-------|
+| Get-CentralInventory | Weekly, Sunday 02:00 | Full inventory is the heaviest job — run off-peak |
+| Get-CentralWaitStats | Every 30 minutes | Reduce to 15 min on high-churn instances |
+| Get-CentralBaselineStats | Every 15 minutes | 1-second DMV snapshot + PerfMon |
+| Invoke-CentralBlitzCollection | Daily, 06:00 | Before business hours — findings are point-in-time |
+| Invoke-CentralBackup (FULL) | Weekly, Saturday 22:00 | Adjust per backup SLA |
+| Invoke-CentralBackup (DIFF) | Weekdays, 22:00 | Adjust per backup SLA |
+| Invoke-CentralBackup (LOG) | Every 15-30 minutes | FULL recovery databases only |
+| Invoke-CentralIndexOptimize | Weekly, Saturday 01:00 | Use `-TimeLimit` to enforce maintenance window |
+| Invoke-CentralIntegrityCheck | Weekly, Sunday 00:00 | Use `-TimeLimit` to enforce maintenance window |
+
+**IntroduceDelay guidance**: On fleets larger than ~20 instances, use `-IntroduceDelay Y` on all jobs. The default range is 1-300 seconds; adjust `-DelaySecMax` to `$fleet_size * 10` to spread CentralDB writes across a reasonable window.
+
+---
+
+## 5. Adding a New Instance
+
+1. **Register the instance** in CentralDB:
+
+```sql
+INSERT INTO [Svr].[ServerList] (ServerName, InstanceName, Active, Baseline)
+VALUES ('NEW-SERVER', 'MSSQLSERVER', 1, 1);
+```
+
+2. **Verify connectivity** from the CMS server (using the proxy credential):
+
+```powershell
+$cred = Get-Credential  # or use the proxy credential
+Connect-DbaInstance -SqlInstance 'NEW-SERVER' -SqlCredential $cred
+```
+
+3. **If using MSX/TSX jobs**: enlist the new server in each multi-server job:
+
+```sql
+EXEC msdb.dbo.sp_add_jobserver
+    @job_name   = 'CentralDB - WaitStats',
+    @server_name = 'NEW-SERVER';
+```
+
+4. **If using CMS-driven (non-MSX) jobs**: no SQL Agent changes needed. The scripts read `[Svr].[ServerList]` at each run.
+
+5. **Validate the first collection**:
+
+```sql
+-- Wait stats
+SELECT TOP 10 * FROM [Inst].[WaitStats]
+WHERE ServerName = 'NEW-SERVER'
+ORDER BY CollectedAt DESC;
+
+-- Inventory
+SELECT TOP 1 * FROM [Svr].[ServerInfo]
+WHERE ServerName = 'NEW-SERVER'
+ORDER BY CollectedAt DESC;
+```
+
+---
+
+## 6. Removing an Instance
+
+Set `Active = 0` — do **not** delete the row, as historical data in all collection tables references it.
+
+```sql
+UPDATE [Svr].[ServerList]
+SET    Active      = 0,
+       LastUpdated = SYSDATETIME()
+WHERE  ServerName   = 'DECOM-SERVER'
+AND    InstanceName = 'MSSQLSERVER';
+```
+
+If using MSX/TSX jobs, also remove the server from each multi-server job:
+
+```sql
+EXEC msdb.dbo.sp_delete_jobserver
+    @job_name   = 'CentralDB - WaitStats',
+    @server_name = 'DECOM-SERVER';
+```
+
+---
+
+## 7. Upgrading dbatools
+
+dbatools releases frequently. Test upgrades in a non-production environment first.
+
+```powershell
+# Check current version on a server
+Get-Module dbatools -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+
+# Update (run as admin)
+Update-Module dbatools -Scope AllUsers
+
+# Verify after update
+Get-Module dbatools -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+```
+
+After upgrading, run each collection script manually with `-Verbose` against a test instance to confirm no breaking changes.
+
+The scripts require dbatools >= 2.0.0 and will throw on startup if the minimum version is not met.
+
+---
+
+## 8. Troubleshooting
+
+### Job reports SUCCESS but no data in CentralDB
+
+CMS write failures are non-fatal by design — a CentralDB outage never aborts a collection run. The script logs a WARN and continues.
+
+**Diagnose**:
+
+```powershell
+.\Collect\Get-CentralWaitStats.ps1 `
+    -SqlInstance 'SQL-01' `
+    -CMSInstanceName 'CMS-01' `
+    -OutputPath 'D:\Temp' `
+    -Verbose
+```
+
+Look for: `[WARN] CMS centralization failed: ...`
+
+Also check the CSV output in `-OutputPath`. If rows are there but not in CentralDB, the collection succeeded and only the write failed. Common causes:
+
+- Proxy account lacks INSERT on the target table in CentralDB
+- CentralDB was unavailable during the run
+- Table schema mismatch (run the stored procedure scripts again)
+
+### Job reports FAILURE on one instance but others succeed
+
+Each instance is processed independently. The script accumulates errors and throws a summary at the end. The SQL Agent job history message will show:
+
+```
+Completed with 1 error(s):
+[Connecting to SQL-03] Failed on SQL-03: A network-related or instance-specific error...
+```
+
+The `[step name]` prefix identifies exactly which phase failed. Common step names:
+- `Connecting to <instance>` — network or auth problem
+- `Executing WaitStats on <instance>` — permission or timeout
+- `Centralizing results to CMS` — CentralDB write (WARN only, not a failure step)
+
+### Script hangs in SQL Agent but works manually
+
+**Cause**: A confirmation prompt is being triggered (ShouldProcess, a first-run module prompt, or a credential popup).
+
+**Fix**:
+1. Verify the job step includes `-NonInteractive`.
+2. Verify dbatools is installed with `-Scope AllUsers` so the proxy account has access without a first-run module initialization prompt.
+3. Run `Import-Module dbatools` once as the proxy account to complete any one-time initialization.
+
+### "dbatools is not installed" error
+
+```
+dbatools is not installed. Install via: Install-Module dbatools
+```
+
+Install on the affected server as an administrator:
+
+```powershell
+Install-Module dbatools -Scope AllUsers -MinimumVersion 2.0.0 -Force
+```
+
+### "dbatools version X found; >= 2.0.0 recommended" warning
+
+This is a warning, not a failure. The script will continue. Upgrade when convenient:
+
+```powershell
+Update-Module dbatools -Scope AllUsers
+```
+
+### "Ola stored proc not found — skipping" warning
+
+```
+[WARN] [Inst.usp_GetBaselineStats not found on SQL-01] Skipping baseline collection.
+```
+
+Scripts emit a warning and skip rather than failing if a required stored procedure is missing. Deploy the solution:
+
+```powershell
+# Ola Hallengren maintenance solution
+Install-DbaMaintenanceSolution -SqlInstance 'SQL-01' -Database 'master' -ReplaceExisting
+
+# First Responder Kit (for Invoke-CentralBlitzCollection)
+Install-DbaFirstResponderKit -SqlInstance 'SQL-01' -Database 'master' -Force
+```
+
+Or set `-DeployOla Y` / `-DeployFRK Y` in the job step to deploy automatically on each run (not recommended for production — prefer a separate one-time deploy job).
+
+### Baseline percentages show values over 100%
+
+This indicates the old `Get-BaselineStats.ps1` stored proc is still deployed. The legacy script had a calculation bug: it used `100 + (delta/base * 100)` instead of the correct `value / base * 100`. Redeploy `Inst.usp_GetBaselineStats.sql` from this branch to correct it.
+
+### CommandLog rows not appearing in [Inst].[CommandLog] after maintenance
+
+1. Verify `CommandLog` table exists in the Ola database (`master` by default):
+   ```sql
+   SELECT TOP 1 * FROM master.dbo.CommandLog;
+   ```
+2. Verify the proxy account has `SELECT` and `DELETE` on `[dbo].[CommandLog]` on the target.
+3. Verify the proxy account has `INSERT` on `[Inst].[CommandLog]` in CentralDB.
+4. Check the SQL Agent job history for WARN messages about centralization failures.
+
+### IntroduceDelay not spreading fleet writes
+
+- Confirm `-IntroduceDelay Y` is in the job step command.
+- Confirm `-DelaySecMax` is wide enough. For 50 instances, a max of 300 seconds means up to ~6 writes per second on CentralDB — increase to 600 if contention is observed.
+- The delay is applied once per script execution (before the first instance), not per instance.
+
+### WhatIf dry-run shows unexpected operations
+
+Scripts use `SupportsShouldProcess`. To preview what will execute without making changes:
+
+```powershell
+.\Collect\Invoke-CentralBackup.ps1 `
+    -SqlInstance 'SQL-01' `
+    -BackupType FULL `
+    -Databases USER_DATABASES `
+    -Directory '\\BACKUPSERVER\Backups' `
+    -OutputPath 'D:\Temp' `
+    -WhatIf
+```
+
+`WhatIf` is filtered from the auto-invoke block and will not cause parameter binding errors.
+
+### Checking what was collected in a specific run
+
+Every collection emits a `LoadGUID`. Pass `-LoadGUID` to correlate a specific run across tables:
+
+```sql
+-- Find all WaitStats rows from a specific run
+SELECT * FROM [Inst].[WaitStats]
+WHERE LoadGUID = '3f2e1a00-...'
+ORDER BY CollectedAt;
+
+-- Find the CommandLog entries for a maintenance run
+SELECT * FROM [Inst].[CommandLog]
+WHERE LoadGUID = '3f2e1a00-...'
+ORDER BY StartTime;
+```
+
+The LoadGUID is also printed in the `[INFO]` verbose output at script start:
+
+```
+[2026-05-31 22:00:01] [INFO] Script v4.1.0 started. LoadGUID: 3f2e1a00-...
+```

--- a/Collect/Get-CentralBaselineStats.ps1
+++ b/Collect/Get-CentralBaselineStats.ps1
@@ -1,0 +1,615 @@
+# ============================================================================
+# PART 1 - Script-level parameter block
+#          Enables: powershell.exe -File Get-CentralBaselineStats.ps1 -Param Value
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+param (
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+
+    [Parameter()]
+    [PSCredential]$SqlCredential,
+
+    [Parameter()]
+    [string]$CMSInstanceName,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$CMSDatabaseName = 'CentralDB',
+
+    [Parameter()]
+    [ValidateRange(60, 86400)]
+    [int]$CommandTimeout = 600,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$IntroduceDelay = 'N',
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMin = 1,
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMax = 300,
+
+    [Parameter()]
+    [switch]$RunLocally,
+
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+    [string]$OutputFormat = 'CSV',
+
+    [Parameter()]
+    [string]$LoadGUID
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Get-CentralBaselineStats {
+<#
+.SYNOPSIS
+    Collects SQL Server and OS baseline performance statistics and
+    centralizes results into CentralDB.
+
+.DESCRIPTION
+    Replaces the legacy Get-BaselineStats.ps1 (SMO + SqlBulkCopy, 2017).
+
+    Three collections per instance:
+
+    SQL Instance Counters ([Inst].[InsBaselineStats]):
+      Calls [Inst].[usp_GetBaselineStats] which takes two snapshots of
+      sys.dm_os_performance_counters one second apart, calculates per-second
+      delta rates, and returns a single pivoted row. Works on both Windows
+      and Linux instances.
+
+    Server OS Baseline ([Svr].[SvrBaselineStats]):
+      Collects CPU %, Processor Queue Length, Avg Disk sec/Read and Write,
+      Avg Disk Queue Length, Available MB, and Paging File % Usage via
+      Get-Counter. Windows instances only - skipped gracefully for Linux.
+
+    Server Drive Baseline ([Svr].[SvrBaselineDriveStats]):
+      Per-physical-drive counters: % disk time, avg disk queue, avg disk
+      read/write latency via Get-Counter. Windows instances only.
+
+    Each collection has independent error handling. A failure in one
+    section does not abort the remaining sections for that instance.
+    CentralDB write failures are non-fatal (WARN only).
+
+.PARAMETER SqlInstance
+    One or more SQL Server instance names. Accepts pipeline input.
+    If omitted, CMS discovery via -CMSInstanceName is used.
+
+.PARAMETER SqlCredential
+    PSCredential for SQL Server authentication. Required for Linux targets.
+
+.PARAMETER CMSInstanceName
+    The CentralDB instance. Used for target discovery and result storage.
+
+.PARAMETER CMSDatabaseName
+    CentralDB database name. Default: CentralDB.
+
+.PARAMETER CommandTimeout
+    Query timeout in seconds. Default: 600. Range: 60-86400.
+    Note: [Inst].[usp_GetBaselineStats] includes a 1-second WAITFOR DELAY.
+    Set CommandTimeout >= 10 to avoid false timeouts.
+
+.PARAMETER IntroduceDelay
+    Set to 'Y' to sleep a random interval before processing.
+    Use in MSX/TSX jobs to stagger simultaneous CentralDB writes.
+
+.PARAMETER DelaySecMin
+    Minimum stagger delay in seconds. Default: 1.
+
+.PARAMETER DelaySecMax
+    Maximum stagger delay in seconds. Default: 300.
+
+.PARAMETER RunLocally
+    Restricts CMS discovery to the local machine only.
+
+.PARAMETER OutputPath
+    Directory for exported output files. Must already exist.
+
+.PARAMETER OutputFormat
+    Output format. Default: CSV.
+
+.PARAMETER LoadGUID
+    Correlation GUID. Generated automatically when omitted.
+
+.EXAMPLE
+    .\Get-CentralBaselineStats.ps1 -SqlInstance 'SQL-01' -CMSInstanceName 'CMS-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run against a single instance.
+
+.EXAMPLE
+    .\Get-CentralBaselineStats.ps1 -CMSInstanceName 'CMS-01' -RunLocally -OutputPath 'D:\Logs'
+    MSX/TSX mode: collects only the local machine.
+
+.EXAMPLE
+    .\Get-CentralBaselineStats.ps1 -SqlInstance '10.0.1.196' -SqlCredential $cred -CMSInstanceName 'localhost' -OutputPath 'D:\Logs'
+    Collect SQL counter baseline from a Linux target (OS section skipped automatically).
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : 2024-01-01
+    Version     : 4.1.0
+    Replaces    : CentralDB/Get-BaselineStats.ps1 (legacy SMO + SqlBulkCopy)
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+    Impact      : LOW - read-only on targets, INSERT on CentralDB
+    Schedule    : Every 15 minutes via SQL Agent
+
+    Permissions :
+        Target    : VIEW SERVER STATE (for sys.dm_os_performance_counters)
+                    EXECUTE on [Inst].[usp_GetBaselineStats]
+        CentralDB : EXECUTE on [Svr].[usp_GetCollectionTargets]
+                    EXECUTE on [Svr].[usp_SetCollectionLastRun]
+                    INSERT on [Inst].[InsBaselineStats]
+                    INSERT on [Svr].[SvrBaselineStats]
+                    INSERT on [Svr].[SvrBaselineDriveStats]
+
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\share\CentralDB\Collect\Get-CentralBaselineStats.ps1"
+                        -CMSInstanceName "$(ESCAPE_DQUOTE(SRVR))"
+                        -RunLocally
+                        -OutputPath "D:\Logs\CentralDB"
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [string[]]$SqlInstance,
+
+        [Parameter()]
+        [PSCredential]$SqlCredential,
+
+        [Parameter()]
+        [string]$CMSInstanceName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CMSDatabaseName = 'CentralDB',
+
+        [Parameter()]
+        [ValidateRange(60, 86400)]
+        [int]$CommandTimeout = 600,
+
+        [Parameter()]
+        [ValidateSet('Y', 'N')]
+        [string]$IntroduceDelay = 'N',
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMin = 1,
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMax = 300,
+
+        [Parameter()]
+        [switch]$RunLocally,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Container })]
+        [string]$OutputPath,
+
+        [Parameter()]
+        [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+        [string]$OutputFormat = 'CSV',
+
+        [Parameter()]
+        [string]$LoadGUID
+    )
+
+    # -------------------------------------------------------------------------
+    begin {
+        #region Module Dependency Check
+        $SCRIPT_VERSION  = '4.1.0'
+        $requiredVersion = [Version]'2.0.0'
+        $dbatoolsMod     = Get-Module -Name dbatools -ListAvailable |
+                               Sort-Object Version -Descending |
+                               Select-Object -First 1
+        if (-not $dbatoolsMod) {
+            throw 'dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers'
+        }
+        if ($dbatoolsMod.Version -lt $requiredVersion) {
+            Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended."
+        }
+        Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+        #endregion
+
+        #region Initialization
+        $ErrorActionPreference = 'Stop'
+        $Script:ErrorCount     = 0
+        $Script:WarningCount   = 0
+        $Script:Results        = New-Object 'System.Collections.Generic.List[PSCustomObject]'
+        $elapsedTime           = [System.Diagnostics.Stopwatch]::StartNew()
+        $stepName              = 'Initialization'
+        $collectedAt           = Get-Date
+
+        if ($LoadGUID) { $runGUID = $LoadGUID }
+        else           { $runGUID = [guid]::NewGuid().ToString() }
+        #endregion
+
+        #region Credential Splats
+        $credParam = @{}
+        if ($SqlCredential) { $credParam['SqlCredential'] = $SqlCredential }
+
+        $cmsCredParam = @{}
+        if ($SqlCredential) { $cmsCredParam['SqlCredential'] = $SqlCredential }
+        #endregion
+
+        #region Write-DbaLog Helper
+        function Write-DbaLog {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory)][string]$Message,
+                [Parameter()][ValidateSet('INFO','WARN','ERROR','DEBUG')][string]$Level = 'INFO'
+            )
+            $ts    = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            $entry = "[$ts] [$Level] $Message"
+            switch ($Level) {
+                'INFO'  { Write-Verbose $entry }
+                'WARN'  { Write-Warning $entry; $Script:WarningCount++ }
+                'ERROR' { Write-Warning "ERROR: $Message"; $Script:ErrorCount++ }
+                'DEBUG' { Write-Debug $entry }
+            }
+        }
+        #endregion
+
+        #region Write-ToCms Helper
+        function Write-ToCms {
+            param (
+                [Parameter(Mandatory)][object]$Data,
+                [Parameter(Mandatory)][string]$Table,
+                [Parameter(Mandatory)][string]$Label
+            )
+            try {
+                $Data | Write-DbaDbTableData `
+                    -SqlInstance $CMSInstanceName `
+                    -Database    $CMSDatabaseName `
+                    -Table       $Table `
+                    -AutoCreateTable `
+                    @cmsCredParam `
+                    -EnableException
+                Write-DbaLog "[$Label] Wrote $(@($Data).Count) row(s) to $Table"
+            }
+            catch {
+                Write-DbaLog "[$Label] CMS write to $Table failed - $($_.Exception.Message)" -Level WARN
+                # Non-fatal: CMS failure must never kill collection
+            }
+        }
+        #endregion
+
+        #region CMS Connection Test
+        function Test-CMSConnection {
+            try {
+                $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @cmsCredParam -ErrorAction Stop
+                return $true
+            }
+            catch { return $false }
+        }
+        #endregion
+
+        Write-DbaLog "Get-CentralBaselineStats v$SCRIPT_VERSION started. LoadGUID: $runGUID"
+
+        #region Stagger Delay
+        if ($IntroduceDelay -eq 'Y') {
+            $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+            Write-DbaLog "Stagger delay: sleeping $delay seconds."
+            Start-Sleep -Seconds $delay
+        }
+        #endregion
+
+        #region Instance Discovery
+        $stepName = 'Instance Discovery'
+        if ($RunLocally) {
+            if (-not $CMSInstanceName) {
+                throw '-CMSInstanceName is required when -RunLocally is specified.'
+            }
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+            $localHost  = $env:COMPUTERNAME
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance    $CMSInstanceName `
+                -Database       $CMSDatabaseName `
+                -Query          'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct, @RunLocally = 1, @LocalServerName = @sn' `
+                -SqlParameters  @{ ct = 'Baseline'; sn = $localHost } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam   -EnableException
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName; $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv }
+            })
+            Write-DbaLog "RunLocally resolved $($SqlInstance.Count) instance(s) for $localHost."
+        }
+        elseif ($CMSInstanceName -and (-not $SqlInstance)) {
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance    $CMSInstanceName `
+                -Database       $CMSDatabaseName `
+                -Query          'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct' `
+                -SqlParameters  @{ ct = 'Baseline' } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam   -EnableException
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName; $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv }
+            })
+            Write-DbaLog "CMS discovery resolved $($SqlInstance.Count) instance(s)."
+        }
+
+        if (-not $SqlInstance -or $SqlInstance.Count -eq 0) {
+            throw 'No target instances resolved. Provide -SqlInstance or configure -CMSInstanceName.'
+        }
+        #endregion
+    }
+
+    # -------------------------------------------------------------------------
+    process {
+        $instanceErrors = New-Object 'System.Collections.Generic.List[string]'
+
+        foreach ($instance in $SqlInstance) {
+
+            $hostName     = ($instance -split '[\\,]')[0]
+            $instancePart = if ($instance -match '\\') { ($instance -split '\\')[1] } else { 'MSSQLSERVER' }
+
+            Write-DbaLog "=== Begin baseline collection: $instance ==="
+
+            # Detect platform
+            $isWindows = $true
+            try {
+                $stepName   = "Platform detection for $instance"
+                # No SqlParameters needed - pure literal query, no user input
+                $platResult = Invoke-DbaQuery `
+                    -SqlInstance    $instance `
+                    -Query          "SELECT @@VERSION AS Ver" `
+                    -CommandTimeout $CommandTimeout `
+                    @credParam      -EnableException
+                if ($platResult.Ver -match 'Linux') { $isWindows = $false }
+                Write-DbaLog "Platform: $($isWindows ? 'Windows' : 'Linux')"
+            }
+            catch {
+                $msg = "Platform detection failed for $($instance) - $($_.Exception.Message)"
+                $instanceErrors.Add($msg)
+                Write-DbaLog $msg -Level ERROR
+                continue
+            }
+
+            $instanceSuccess = $true
+
+            # =================================================================
+            #region Collection 1: SQL Instance Counters (all platforms)
+            # =================================================================
+            $stepName = "SQL instance counters - $instance"
+            try {
+                Write-DbaLog "[SQLCounters] Collecting via [Inst].[usp_GetBaselineStats] on $instance"
+                $sqlCounters = Invoke-DbaQuery `
+                    -SqlInstance    $instance `
+                    -Query          'EXEC [Inst].[usp_GetBaselineStats] @ServerName = @sv, @InstanceName = @in' `
+                    -SqlParameters  @{ sv = $hostName; in = $instancePart } `
+                    -CommandTimeout $CommandTimeout `
+                    @credParam      -EnableException
+
+                if ($sqlCounters) {
+                    if ($PSCmdlet.ShouldProcess($instance, 'Write SQL counter baseline to CentralDB')) {
+                        Write-ToCms -Data $sqlCounters -Table '[Inst].[InsBaselineStats]' -Label 'SQLCounters'
+                    }
+                }
+                else {
+                    Write-DbaLog '[SQLCounters] No rows returned from stored procedure.' -Level WARN
+                }
+            }
+            catch {
+                $instanceSuccess = $false
+                Write-DbaLog "[SQLCounters] $($instance) - $($_.Exception.Message)" -Level ERROR
+            }
+            #endregion
+
+            # =================================================================
+            #region Collection 2: Server OS Baseline (Windows only)
+            # =================================================================
+            $stepName = "Server OS baseline - $instance"
+            if (-not $isWindows) {
+                Write-DbaLog '[SvrBaseline] Skipped - Linux instance.' -Level WARN
+            }
+            else {
+                try {
+                    Write-DbaLog "[SvrBaseline] Collecting PerfMon counters from $hostName"
+
+                    # Processor counters
+                    $procTotal = Get-Counter -Counter '\Processor(_total)\% Processor Time' `
+                                             -ComputerName $hostName -ErrorAction Stop
+                    $pctProcTm = $procTotal.CounterSamples[0].CookedValue
+
+                    $procQueue = Get-Counter -Counter '\System\Processor Queue Length' `
+                                             -ComputerName $hostName -ErrorAction Stop
+                    $procQLen  = $procQueue.CounterSamples[0].CookedValue
+
+                    # Disk counters
+                    $dskRd    = Get-Counter -Counter '\PhysicalDisk(_total)\Avg. Disk sec/Read' `
+                                            -ComputerName $hostName -ErrorAction Stop
+                    $avDskRd  = $dskRd.CounterSamples[0].CookedValue
+
+                    $dskWt    = Get-Counter -Counter '\PhysicalDisk(_total)\Avg. Disk sec/Write' `
+                                            -ComputerName $hostName -ErrorAction Stop
+                    $avDskWt  = $dskWt.CounterSamples[0].CookedValue
+
+                    $dskQ     = Get-Counter -Counter '\PhysicalDisk(_total)\Avg. Disk Queue Length' `
+                                            -ComputerName $hostName -ErrorAction Stop
+                    $avDskQLen = $dskQ.CounterSamples[0].CookedValue
+
+                    # Memory counters
+                    $avlMB    = Get-Counter -Counter '\Memory\Available MBytes' `
+                                            -ComputerName $hostName -ErrorAction Stop
+                    $availMB  = $avlMB.CounterSamples[0].CookedValue
+
+                    $pgFile   = Get-Counter -Counter '\Paging File(_total)\% Usage' `
+                                            -ComputerName $hostName -ErrorAction Stop
+                    $pgFlUsg  = $pgFile.CounterSamples[0].CookedValue
+
+                    $svrRow = [PSCustomObject]@{
+                        ServerName   = $hostName
+                        InstanceName = $instance
+                        PctProcTm    = [math]::Round($pctProcTm,  2)
+                        ProcQLen     = [math]::Round($procQLen,    0)
+                        AvDskRd      = [math]::Round($avDskRd,     6)
+                        AvDskWt      = [math]::Round($avDskWt,     6)
+                        AvDskQLen    = [math]::Round($avDskQLen,   2)
+                        AvailMB      = [math]::Round($availMB,     0)
+                        PgFlUsg      = [math]::Round($pgFlUsg,     2)
+                        LoadGUID     = $runGUID
+                        CollectedAt  = $collectedAt
+                    }
+
+                    if ($PSCmdlet.ShouldProcess($instance, 'Write server OS baseline to CentralDB')) {
+                        Write-ToCms -Data $svrRow -Table '[Svr].[SvrBaselineStats]' -Label 'SvrBaseline'
+                    }
+                }
+                catch {
+                    Write-DbaLog "[SvrBaseline] $($instance) - $($_.Exception.Message)" -Level WARN
+                    # Non-fatal: OS counter failure does not fail the instance
+                }
+            }
+            #endregion
+
+            # =================================================================
+            #region Collection 3: Per-Drive Baseline (Windows only)
+            # =================================================================
+            $stepName = "Drive baseline - $instance"
+            if (-not $isWindows) {
+                Write-DbaLog '[DriveBaseline] Skipped - Linux instance.' -Level WARN
+            }
+            else {
+                try {
+                    Write-DbaLog "[DriveBaseline] Collecting per-drive counters from $hostName"
+
+                    $driveCounters = @(
+                        '\PhysicalDisk(*)\% Disk Time',
+                        '\PhysicalDisk(*)\Avg. Disk Queue Length',
+                        '\PhysicalDisk(*)\Avg. Disk sec/Read',
+                        '\PhysicalDisk(*)\Avg. Disk sec/Write'
+                    )
+
+                    $rawCounters = Get-Counter -Counter $driveCounters `
+                                               -ComputerName $hostName -ErrorAction Stop
+
+                    $driveRows = $rawCounters.CounterSamples | Select-Object `
+                        @{ n = 'ServerName';   e = { $hostName } },
+                        @{ n = 'Drive';        e = {
+                            if ($_.InstanceName -eq '_total') { 'Total' }
+                            else {
+                                $clean = $_.InstanceName.ToUpper() -replace '_', ''
+                                if ($clean.Length -ge 2) { $clean.Substring($clean.Length - 2, 2) }
+                                else { $clean }
+                            }
+                        }},
+                        @{ n = 'CounterType';  e = { $_.Path.Substring($_.Path.LastIndexOf('\') + 1) } },
+                        @{ n = 'Value';        e = { [math]::Round($_.CookedValue, 6) } },
+                        @{ n = 'LoadGUID';     e = { $runGUID } },
+                        @{ n = 'CollectedAt';  e = { $collectedAt } }
+
+                    if ($PSCmdlet.ShouldProcess($instance, 'Write drive baseline to CentralDB')) {
+                        Write-ToCms -Data $driveRows -Table '[Svr].[SvrBaselineDriveStats]' -Label 'DriveBaseline'
+                    }
+                }
+                catch {
+                    Write-DbaLog "[DriveBaseline] $($instance) - $($_.Exception.Message)" -Level WARN
+                    # Non-fatal: drive counter failure does not fail the instance
+                }
+            }
+            #endregion
+
+            # =================================================================
+            # Update CMS collection timestamp
+            # =================================================================
+            if ($PSCmdlet.ShouldProcess($instance, 'Update baseline collection timestamp in CentralDB')) {
+                try {
+                    Invoke-DbaQuery `
+                        -SqlInstance    $CMSInstanceName `
+                        -Database       $CMSDatabaseName `
+                        -Query          'EXEC [Svr].[usp_SetCollectionLastRun] @CollectionType = @ct, @ServerName = @sv, @InstanceName = @in, @LoadGUID = @lg' `
+                        -SqlParameters  @{ ct = 'Baseline'; sv = $hostName; in = $instancePart; lg = $runGUID } `
+                        -CommandTimeout $CommandTimeout `
+                        @cmsCredParam   -EnableException
+                }
+                catch {
+                    Write-DbaLog "Failed to update collection timestamp for $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+            }
+
+            Write-DbaLog "=== Completed $instance ==="
+
+            $Script:Results.Add([PSCustomObject]@{
+                PSTypeName   = 'CentralDB.BaselineStatsResult'
+                SqlInstance  = $instance
+                IsWindows    = $isWindows
+                LoadGUID     = $runGUID
+                CollectedAt  = $collectedAt
+                Status       = if ($instanceSuccess) { 'Success' } else { 'PartialSuccess' }
+                ErrorMessage = $null
+            })
+        }
+
+        if ($instanceErrors.Count -gt 0) {
+            $summary = $instanceErrors -join "`n"
+            throw "Get-CentralBaselineStats completed with $($instanceErrors.Count) instance error(s):`n$summary"
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    end {
+        $elapsedTime.Stop()
+        $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+
+        if ($Script:ErrorCount -gt 0) {
+            Write-Warning "Get-CentralBaselineStats completed with $Script:ErrorCount error(s) in $duration."
+        }
+        else {
+            Write-DbaLog "Get-CentralBaselineStats completed successfully in $duration."
+        }
+
+        #region Export Output
+        $exportBase = Join-Path $OutputPath ("BaselineStats_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss')")
+
+        switch ($OutputFormat) {
+            'CSV'      { $Script:Results | Export-Csv -Path "$exportBase.csv"  -NoTypeInformation }
+            'JSON'     { $Script:Results | ConvertTo-Json -Depth 5 | Out-File -FilePath "$exportBase.json" -Encoding utf8 }
+            'HTML'     { $Script:Results | ConvertTo-Html -Title 'CentralDB Baseline Stats' | Out-File -FilePath "$exportBase.html" -Encoding utf8 }
+            'GridView' { $Script:Results | Out-GridView -Title 'CentralDB Baseline Stats' }
+            'Excel'    {
+                if (Get-Module -Name ImportExcel -ListAvailable) {
+                    $Script:Results | Export-Excel -Path "$exportBase.xlsx" -AutoSize -FreezeTopRow
+                }
+                else {
+                    Write-DbaLog 'ImportExcel not found - falling back to CSV.' -Level WARN
+                    $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation
+                }
+            }
+        }
+
+        Write-DbaLog "Output written to $exportBase.$($OutputFormat.ToLower())"
+        #endregion
+
+        $Script:Results
+    }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION: forwards script params to the function
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') {
+        $invokeParams[$key] = $PSBoundParameters[$key]
+    }
+}
+Get-CentralBaselineStats @invokeParams -Confirm:$false

--- a/Collect/Get-CentralInventory.ps1
+++ b/Collect/Get-CentralInventory.ps1
@@ -1,0 +1,1044 @@
+# ============================================================================
+# PART 1 - Script-level parameter block
+#          Enables: powershell.exe -File Get-CentralInventory.ps1 -Param Value
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+param (
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+
+    [Parameter()]
+    [PSCredential]$SqlCredential,
+
+    [Parameter()]
+    [string]$CMSInstanceName,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$CMSDatabaseName = 'CentralDB',
+
+    [Parameter()]
+    [ValidateRange(60, 86400)]
+    [int]$CommandTimeout = 600,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$IntroduceDelay = 'N',
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMin = 1,
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMax = 300,
+
+    [Parameter()]
+    [switch]$RunLocally,
+
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+    [string]$OutputFormat = 'CSV',
+
+    [Parameter()]
+    [string]$LoadGUID,
+
+    [Parameter()]
+    [ValidateSet('All', 'ServerOS', 'Instance', 'Databases', 'HA', 'SSRS')]
+    [string[]]$Sections = @('All')
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Get-CentralInventory {
+<#
+.SYNOPSIS
+    Collects a full SQL Server estate inventory and centralizes results
+    into CentralDB across six sections: ServerOS, Instance, Databases,
+    HA, and SSRS.
+
+.DESCRIPTION
+    Replaces the legacy Get-Inventory.ps1 (WMI + SMO, 2017).
+    Uses dbatools throughout and supports both Windows and Linux instances.
+
+    Sections collected per instance:
+    - ServerOS   : OS info, patch history, page file, disk space, SQL services
+                   (Windows instances only - skipped gracefully for Linux)
+    - Instance   : SQL build/compliance, instance properties, sp_configure,
+                   logins, linked servers, instance-level triggers,
+                   agent jobs, failed jobs
+    - Databases  : Database properties, files, file growth events,
+                   backup history, DB role members, user permissions,
+                   missing indexes, last good DBCC
+    - HA         : Availability groups, AG databases, AG replicas
+    - SSRS       : Reporting Services instance info
+                   (Windows instances only)
+
+    Each section has independent error handling - a failure in one section
+    does not stop collection of subsequent sections for that instance.
+    CentralDB write failures are non-fatal (WARN only).
+
+.PARAMETER SqlInstance
+    One or more SQL Server instance names. Accepts hostname,
+    hostname\instance, or hostname,port. Accepts pipeline input.
+    If omitted, CMS discovery via -CMSInstanceName is used.
+
+.PARAMETER SqlCredential
+    PSCredential for SQL Server authentication on target instances.
+    Required for Linux targets and SQL-auth-only environments.
+
+.PARAMETER CMSInstanceName
+    The CentralDB SQL Server instance used to resolve the target list
+    and as the destination for centralized inventory data.
+
+.PARAMETER CMSDatabaseName
+    The CentralDB database name. Default: CentralDB.
+
+.PARAMETER CommandTimeout
+    Query timeout in seconds. Default: 600. Range: 60-86400.
+
+.PARAMETER IntroduceDelay
+    Set to 'Y' to sleep a random interval before processing.
+    Use in MSX/TSX jobs to stagger simultaneous CentralDB writes.
+
+.PARAMETER DelaySecMin
+    Minimum stagger delay in seconds. Default: 1.
+
+.PARAMETER DelaySecMax
+    Maximum stagger delay in seconds. Default: 300.
+
+.PARAMETER RunLocally
+    Restricts CMS discovery to the local machine. Use in MSX/TSX
+    SQL Agent jobs so each server collects its own inventory only.
+
+.PARAMETER OutputPath
+    Directory for exported output files. Must already exist.
+
+.PARAMETER OutputFormat
+    Output format. Default: CSV.
+    Supported: CSV, HTML, JSON, Excel, GridView.
+
+.PARAMETER LoadGUID
+    Correlation GUID for this collection run. A new GUID is generated
+    when omitted. Pass the same GUID across all collection scripts in
+    a scheduled run to correlate results in CentralDB.
+
+.PARAMETER Sections
+    Restrict collection to specific sections. Default: All.
+    Values: All, ServerOS, Instance, Databases, HA, SSRS.
+    Example: -Sections Instance,Databases
+
+.EXAMPLE
+    .\Get-CentralInventory.ps1 -SqlInstance 'SQL-01' -CMSInstanceName 'CMS-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run against a single instance. Nothing is written.
+
+.EXAMPLE
+    .\Get-CentralInventory.ps1 -CMSInstanceName 'CMS-01' -RunLocally -OutputPath 'D:\Logs'
+    MSX/TSX mode: discovers instances from CentralDB filtered to local machine.
+
+.EXAMPLE
+    .\Get-CentralInventory.ps1 -SqlInstance '10.0.1.129' -SqlCredential $cred -CMSInstanceName 'localhost' -Sections Instance,Databases -OutputPath 'D:\Logs'
+    Collect only Instance and Database sections from a Linux target.
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : 2024-01-01
+    Version     : 4.1.0
+    Replaces    : CentralDB/Get-Inventory.ps1 (legacy WMI + SMO)
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+    Impact      : LOW - read-only on targets, INSERT on CentralDB
+    Schedule    : Weekly via SQL Agent (recommended: Sunday 02:00)
+
+    Permissions :
+        Target    : VIEW SERVER STATE, VIEW ANY DATABASE
+                    db_datareader on msdb
+        CentralDB : EXECUTE on [Svr].[usp_GetCollectionTargets]
+                    EXECUTE on [Svr].[usp_SetCollectionLastRun]
+                    INSERT on [Svr].*, [Inst].*, [DB].*, [RS].*
+
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\share\CentralDB\Collect\Get-CentralInventory.ps1"
+                        -CMSInstanceName "$(ESCAPE_DQUOTE(SRVR))"
+                        -RunLocally
+                        -OutputPath "D:\Logs\CentralDB"
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [string[]]$SqlInstance,
+
+        [Parameter()]
+        [PSCredential]$SqlCredential,
+
+        [Parameter()]
+        [string]$CMSInstanceName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CMSDatabaseName = 'CentralDB',
+
+        [Parameter()]
+        [ValidateRange(60, 86400)]
+        [int]$CommandTimeout = 600,
+
+        [Parameter()]
+        [ValidateSet('Y', 'N')]
+        [string]$IntroduceDelay = 'N',
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMin = 1,
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMax = 300,
+
+        [Parameter()]
+        [switch]$RunLocally,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Container })]
+        [string]$OutputPath,
+
+        [Parameter()]
+        [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+        [string]$OutputFormat = 'CSV',
+
+        [Parameter()]
+        [string]$LoadGUID,
+
+        [Parameter()]
+        [ValidateSet('All', 'ServerOS', 'Instance', 'Databases', 'HA', 'SSRS')]
+        [string[]]$Sections = @('All')
+    )
+
+    # -------------------------------------------------------------------------
+    begin {
+        #region Module Dependency Check
+        $SCRIPT_VERSION  = '4.1.0'
+        $requiredVersion = [Version]'2.0.0'
+        $dbatoolsMod     = Get-Module -Name dbatools -ListAvailable |
+                               Sort-Object Version -Descending |
+                               Select-Object -First 1
+        if (-not $dbatoolsMod) {
+            throw 'dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers'
+        }
+        if ($dbatoolsMod.Version -lt $requiredVersion) {
+            Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended."
+        }
+        Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+        #endregion
+
+        #region Initialization
+        $ErrorActionPreference = 'Stop'
+        $Script:ErrorCount     = 0
+        $Script:WarningCount   = 0
+        $Script:Results        = New-Object 'System.Collections.Generic.List[PSCustomObject]'
+        $elapsedTime           = [System.Diagnostics.Stopwatch]::StartNew()
+        $stepName              = 'Initialization'
+        $collectedAt           = Get-Date
+
+        if ($LoadGUID) { $runGUID = $LoadGUID }
+        else           { $runGUID = [guid]::NewGuid().ToString() }
+
+        $runAll = $Sections -contains 'All'
+        #endregion
+
+        #region Credential Splats
+        $credParam = @{}
+        if ($SqlCredential) { $credParam['SqlCredential'] = $SqlCredential }
+
+        $cmsCredParam = @{}
+        if ($SqlCredential) { $cmsCredParam['SqlCredential'] = $SqlCredential }
+        #endregion
+
+        #region Write-DbaLog Helper
+        function Write-DbaLog {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory)][string]$Message,
+                [Parameter()][ValidateSet('INFO','WARN','ERROR','DEBUG')][string]$Level = 'INFO'
+            )
+            $ts    = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            $entry = "[$ts] [$Level] $Message"
+            switch ($Level) {
+                'INFO'  { Write-Verbose $entry }
+                'WARN'  { Write-Warning $entry; $Script:WarningCount++ }
+                'ERROR' { Write-Warning "ERROR: $Message"; $Script:ErrorCount++ }
+                'DEBUG' { Write-Debug $entry }
+            }
+        }
+        #endregion
+
+        #region Write-Tocms Helper
+        function Write-ToCms {
+            param (
+                [Parameter(Mandatory)][object]$Data,
+                [Parameter(Mandatory)][string]$Table,
+                [Parameter(Mandatory)][string]$Section
+            )
+            try {
+                $Data | Write-DbaDbTableData `
+                    -SqlInstance $CMSInstanceName `
+                    -Database    $CMSDatabaseName `
+                    -Table       $Table `
+                    -AutoCreateTable `
+                    @cmsCredParam `
+                    -EnableException
+                Write-DbaLog "[$Section] Wrote $(@($Data).Count) row(s) to $Table"
+            }
+            catch {
+                Write-DbaLog "[$Section] CMS write to $Table failed - $($_.Exception.Message)" -Level WARN
+                # Non-fatal: CMS failure must never kill collection
+            }
+        }
+        #endregion
+
+        #region CMS Connection Test
+        function Test-CMSConnection {
+            try {
+                $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @cmsCredParam -ErrorAction Stop
+                return $true
+            }
+            catch { return $false }
+        }
+        #endregion
+
+        Write-DbaLog "Get-CentralInventory v$SCRIPT_VERSION started. LoadGUID: $runGUID"
+        Write-DbaLog "Sections: $($Sections -join ', ')"
+
+        #region Stagger Delay
+        if ($IntroduceDelay -eq 'Y') {
+            $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+            Write-DbaLog "Stagger delay: sleeping $delay seconds."
+            Start-Sleep -Seconds $delay
+        }
+        #endregion
+
+        #region Instance Discovery
+        $stepName = 'Instance Discovery'
+        if ($RunLocally) {
+            if (-not $CMSInstanceName) {
+                throw '-CMSInstanceName is required when -RunLocally is specified.'
+            }
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+            $localHost  = $env:COMPUTERNAME
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance    $CMSInstanceName `
+                -Database       $CMSDatabaseName `
+                -Query          'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct, @RunLocally = 1, @LocalServerName = @sn' `
+                -SqlParameters  @{ ct = 'Inventory'; sn = $localHost } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam   -EnableException
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName; $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv }
+            })
+            Write-DbaLog "RunLocally resolved $($SqlInstance.Count) instance(s) for $localHost."
+        }
+        elseif ($CMSInstanceName -and (-not $SqlInstance)) {
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance    $CMSInstanceName `
+                -Database       $CMSDatabaseName `
+                -Query          'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct' `
+                -SqlParameters  @{ ct = 'Inventory' } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam   -EnableException
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName; $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv }
+            })
+            Write-DbaLog "CMS discovery resolved $($SqlInstance.Count) instance(s)."
+        }
+
+        if (-not $SqlInstance -or $SqlInstance.Count -eq 0) {
+            throw 'No target instances resolved. Provide -SqlInstance or configure -CMSInstanceName.'
+        }
+        #endregion
+    }
+
+    # -------------------------------------------------------------------------
+    process {
+        $instanceErrors = New-Object 'System.Collections.Generic.List[string]'
+
+        foreach ($instance in $SqlInstance) {
+
+            $hostName     = ($instance -split '[\\,]')[0]
+            $instancePart = if ($instance -match '\\') { ($instance -split '\\')[1] } else { 'MSSQLSERVER' }
+            $sectionsDone = New-Object 'System.Collections.Generic.List[string]'
+            $sectionsFailed = New-Object 'System.Collections.Generic.List[string]'
+
+            Write-DbaLog "=== Begin inventory: $instance ==="
+
+            # Detect platform - Linux targets skip WMI-based sections gracefully
+            $stepName  = "Detecting platform for $instance"
+            $isWindows = $true
+            try {
+                # No SqlParameters needed - query is a pure literal with no user input
+                $platResult = Invoke-DbaQuery `
+                    -SqlInstance    $instance `
+                    -Query          "SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT) AS EngEd, @@VERSION AS Ver" `
+                    -CommandTimeout $CommandTimeout `
+                    @credParam      -EnableException
+                if ($platResult.Ver -match 'Linux') { $isWindows = $false }
+                Write-DbaLog "Platform: $($isWindows ? 'Windows' : 'Linux')"
+            }
+            catch {
+                $msg = "Platform detection failed for $($instance) - $($_.Exception.Message)"
+                $instanceErrors.Add($msg)
+                Write-DbaLog $msg -Level ERROR
+                continue
+            }
+
+            # =================================================================
+            #region Section: ServerOS
+            # =================================================================
+            if ($runAll -or $Sections -contains 'ServerOS') {
+                $stepName = "ServerOS - $instance"
+
+                if (-not $isWindows) {
+                    Write-DbaLog "[ServerOS] Skipped for Linux instance $instance." -Level WARN
+                }
+                else {
+                    # -- OS Info -----------------------------------------------
+                    try {
+                        $osData = Get-CimInstance -ClassName Win32_OperatingSystem -ComputerName $hostName -ErrorAction Stop
+                        $lastBoot = New-TimeSpan -Start ($osData.LastBootUpTime) -End (Get-Date)
+                        $uptime   = '{0} Days, {1} Hrs' -f $lastBoot.Days, $lastBoot.Hours
+
+                        $osRows = $osData | Select-Object `
+                            @{ n = 'ServerName';   e = { $hostName } },
+                            @{ n = 'OSName';       e = { $_.Caption } },
+                            @{ n = 'OSVersion';    e = { $_.Version } },
+                            @{ n = 'OSBuildNo';    e = { $_.BuildNumber } },
+                            @{ n = 'ServicePack';  e = { $_.ServicePackMajorVersion } },
+                            @{ n = 'OSArchitect';  e = { $_.OSArchitecture } },
+                            @{ n = 'UpTimeHrs';    e = { $uptime } },
+                            @{ n = 'LastBootTime'; e = { $_.LastBootUpTime } },
+                            @{ n = 'LoadGUID';     e = { $runGUID } },
+                            @{ n = 'CollectedAt';  e = { $collectedAt } }
+
+                        Write-ToCms -Data $osRows -Table '[Svr].[OSInfo]' -Section 'ServerOS'
+                    }
+                    catch {
+                        Write-DbaLog "[ServerOS][OSInfo] $($instance) - $($_.Exception.Message)" -Level WARN
+                    }
+
+                    # -- OS Patches -------------------------------------------
+                    try {
+                        $patches = Get-CimInstance -ClassName Win32_QuickFixEngineering -ComputerName $hostName -ErrorAction Stop
+                        $patchRows = $patches | Select-Object `
+                            @{ n = 'ServerName';  e = { $hostName } },
+                            Caption, Description, HotFixID, InstalledBy, InstalledOn,
+                            @{ n = 'LoadGUID';    e = { $runGUID } },
+                            @{ n = 'CollectedAt'; e = { $collectedAt } }
+
+                        Write-ToCms -Data $patchRows -Table '[Svr].[OSPatchInfo]' -Section 'ServerOS'
+                    }
+                    catch {
+                        Write-DbaLog "[ServerOS][OSPatchInfo] $($instance) - $($_.Exception.Message)" -Level WARN
+                    }
+
+                    # -- Page File --------------------------------------------
+                    try {
+                        $pgFile = Get-CimInstance -ClassName Win32_PageFileUsage -ComputerName $hostName -ErrorAction Stop
+                        $pgRows = $pgFile | Select-Object `
+                            @{ n = 'ServerName';          e = { $hostName } },
+                            Name,
+                            @{ n = 'PgAllocBaseSzInGB';   e = { [math]::Round($_.AllocatedBaseSize / 1024, 2) } },
+                            @{ n = 'PgCurrUsageInGB';     e = { [math]::Round($_.CurrentUsage     / 1024, 2) } },
+                            @{ n = 'PgPeakUsageInGB';     e = { [math]::Round($_.PeakUsage        / 1024, 2) } },
+                            @{ n = 'LoadGUID';            e = { $runGUID } },
+                            @{ n = 'CollectedAt';         e = { $collectedAt } }
+
+                        Write-ToCms -Data $pgRows -Table '[Svr].[PgFileUsage]' -Section 'ServerOS'
+                    }
+                    catch {
+                        Write-DbaLog "[ServerOS][PgFileUsage] $($instance) - $($_.Exception.Message)" -Level WARN
+                    }
+
+                    # -- Server / Hardware ------------------------------------
+                    try {
+                        $compSys  = Get-DbaComputerSystem -ComputerName $hostName -EnableException
+                        $srvRows  = $compSys | Select-Object `
+                            @{ n = 'ServerName';                  e = { $hostName } },
+                            @{ n = 'Model';                       e = { $_.Model } },
+                            @{ n = 'Manufacturer';                e = { $_.Manufacturer } },
+                            @{ n = 'Domain';                      e = { $_.Domain } },
+                            @{ n = 'TotalPhysicalMemoryInGB';     e = { [math]::Round($_.TotalPhysicalMemory / 1GB, 2) } },
+                            @{ n = 'NumberOfProcessors';          e = { $_.NumberOfProcessors } },
+                            @{ n = 'NumberOfLogicalProcessors';   e = { $_.NumberOfLogicalProcessors } },
+                            @{ n = 'IsVM';                        e = { $_.Model -match 'Virtual' } },
+                            @{ n = 'LoadGUID';                    e = { $runGUID } },
+                            @{ n = 'CollectedAt';                 e = { $collectedAt } }
+
+                        Write-ToCms -Data $srvRows -Table '[Svr].[ServerInfo]' -Section 'ServerOS'
+                    }
+                    catch {
+                        Write-DbaLog "[ServerOS][ServerInfo] $($instance) - $($_.Exception.Message)" -Level WARN
+                    }
+
+                    # -- Disk Space -------------------------------------------
+                    try {
+                        $disks    = Get-DbaDiskSpace -ComputerName $hostName -EnableException
+                        $diskRows = $disks | Select-Object `
+                            @{ n = 'ServerName';        e = { $hostName } },
+                            @{ n = 'Name';              e = { $_.Name } },
+                            @{ n = 'Label';             e = { $_.Label } },
+                            @{ n = 'FileSystem';        e = { $_.FileSystem } },
+                            @{ n = 'DskTotalSizeInGB';  e = { [math]::Round($_.Capacity  / 1GB, 2) } },
+                            @{ n = 'DskFreeSpaceInGB';  e = { [math]::Round($_.Free      / 1GB, 2) } },
+                            @{ n = 'DskUsedSpaceInGB';  e = { [math]::Round(($_.Capacity - $_.Free) / 1GB, 2) } },
+                            @{ n = 'DskPctFree';        e = { if ($_.Capacity -gt 0) { [math]::Round(($_.Free / $_.Capacity) * 100, 2) } else { 0 } } },
+                            @{ n = 'BlockSizeInKB';     e = { $_.BlockSize / 1KB } },
+                            @{ n = 'IsSqlDisk';         e = { $_.IsSqlDisk } },
+                            @{ n = 'LoadGUID';          e = { $runGUID } },
+                            @{ n = 'CollectedAt';       e = { $collectedAt } }
+
+                        Write-ToCms -Data $diskRows -Table '[Svr].[DiskInfo]' -Section 'ServerOS'
+                    }
+                    catch {
+                        Write-DbaLog "[ServerOS][DiskInfo] $($instance) - $($_.Exception.Message)" -Level WARN
+                    }
+
+                    # -- SQL Services -----------------------------------------
+                    try {
+                        $services = Get-DbaService -ComputerName $hostName -EnableException
+                        $svcRows  = $services | Select-Object `
+                            @{ n = 'ServerName';    e = { $hostName } },
+                            ServiceName, DisplayName, State, StartMode,
+                            @{ n = 'ServiceAccount'; e = { $_.StartName } },
+                            @{ n = 'ProcessId';      e = { $_.ProcessId } },
+                            @{ n = 'LoadGUID';       e = { $runGUID } },
+                            @{ n = 'CollectedAt';    e = { $collectedAt } }
+
+                        Write-ToCms -Data $svcRows -Table '[Svr].[SQLServices]' -Section 'ServerOS'
+                    }
+                    catch {
+                        Write-DbaLog "[ServerOS][SQLServices] $($instance) - $($_.Exception.Message)" -Level WARN
+                    }
+                }
+                $sectionsDone.Add('ServerOS')
+            }
+            #endregion ServerOS
+
+            # =================================================================
+            #region Section: Instance
+            # =================================================================
+            if ($runAll -or $Sections -contains 'Instance') {
+                $stepName = "Instance - $instance"
+
+                # -- Build Compliance -----------------------------------------
+                try {
+                    $buildInfo = Test-DbaBuild -SqlInstance $instance @credParam -Latest -EnableException
+                    $buildRows = $buildInfo | Select-Object `
+                        @{ n = 'ServerName';    e = { $hostName } },
+                        @{ n = 'InstanceName';  e = { $instance } },
+                        @{ n = 'SQLVersion';    e = { $_.NameLevel } },
+                        @{ n = 'Build';         e = { $_.Build } },
+                        @{ n = 'BuildTarget';   e = { $_.BuildTarget } },
+                        @{ n = 'Compliant';     e = { $_.Compliant } },
+                        @{ n = 'SPLevel';       e = { $_.SPLevel } },
+                        @{ n = 'CULevel';       e = { $_.CULevel } },
+                        @{ n = 'SupportedUntil';e = { $_.SupportedUntil } },
+                        @{ n = 'LoadGUID';      e = { $runGUID } },
+                        @{ n = 'CollectedAt';   e = { $collectedAt } }
+
+                    Write-ToCms -Data $buildRows -Table '[Inst].[BuildCompliance]' -Section 'Instance'
+                }
+                catch {
+                    Write-DbaLog "[Instance][BuildCompliance] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Instance Properties --------------------------------------
+                try {
+                    $instProps = Get-DbaInstanceProperty -SqlInstance $instance @credParam -EnableException
+                    # Pivot key properties to a single row per instance
+                    $propHash = @{}
+                    foreach ($p in $instProps) { $propHash[$p.Name] = $p.Value }
+
+                    $instRow = [PSCustomObject]@{
+                        ServerName              = $hostName
+                        InstanceName            = $instance
+                        Edition                 = if ($propHash['Edition'])             { $propHash['Edition'] }             else { $null }
+                        ProductVersion          = if ($propHash['ProductVersion'])       { $propHash['ProductVersion'] }       else { $null }
+                        ProductLevel            = if ($propHash['ProductLevel'])         { $propHash['ProductLevel'] }         else { $null }
+                        ProductUpdateLevel      = if ($propHash['ProductUpdateLevel'])   { $propHash['ProductUpdateLevel'] }   else { $null }
+                        Collation               = if ($propHash['Collation'])            { $propHash['Collation'] }            else { $null }
+                        MaxServerMemoryMB       = if ($propHash['MaxServerMemory'])      { $propHash['MaxServerMemory'] }      else { $null }
+                        MinServerMemoryMB       = if ($propHash['MinServerMemory'])      { $propHash['MinServerMemory'] }      else { $null }
+                        MaxDOP                  = if ($propHash['MaxDegreeOfParallelism']){ $propHash['MaxDegreeOfParallelism'] } else { $null }
+                        CostThresholdParallel   = if ($propHash['CostThresholdForParallelism']) { $propHash['CostThresholdForParallelism'] } else { $null }
+                        IsHadrEnabled           = if ($propHash['IsHadrEnabled'])        { $propHash['IsHadrEnabled'] }        else { $null }
+                        IsClustered             = if ($propHash['IsClustered'])           { $propHash['IsClustered'] }          else { $null }
+                        NumLogicalProcessors    = if ($propHash['ProcessorCount'])       { $propHash['ProcessorCount'] }       else { $null }
+                        LoadGUID                = $runGUID
+                        CollectedAt             = $collectedAt
+                    }
+
+                    Write-ToCms -Data $instRow -Table '[Inst].[InstanceInfo]' -Section 'Instance'
+                }
+                catch {
+                    Write-DbaLog "[Instance][InstanceInfo] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Logins ---------------------------------------------------
+                try {
+                    $logins   = Get-DbaLogin -SqlInstance $instance @credParam -EnableException
+                    $loginRows = $logins | Select-Object `
+                        @{ n = 'ServerName';    e = { $hostName } },
+                        @{ n = 'InstanceName';  e = { $instance } },
+                        Name, LoginType, IsDisabled, IsLocked, MustChangePassword,
+                        CreateDate, DateLastModified,
+                        @{ n = 'DefaultDatabase'; e = { $_.DefaultDatabase } },
+                        @{ n = 'HasAccess';       e = { $_.HasAccess } },
+                        @{ n = 'LoadGUID';        e = { $runGUID } },
+                        @{ n = 'CollectedAt';     e = { $collectedAt } }
+
+                    Write-ToCms -Data $loginRows -Table '[Inst].[Logins]' -Section 'Instance'
+                }
+                catch {
+                    Write-DbaLog "[Instance][Logins] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Server Role Members --------------------------------------
+                try {
+                    $srvRoles = Get-DbaServerRoleMember -SqlInstance $instance @credParam -EnableException
+                    $roleRows = $srvRoles | Select-Object `
+                        @{ n = 'ServerName';   e = { $hostName } },
+                        @{ n = 'InstanceName'; e = { $instance } },
+                        Role, Name,
+                        @{ n = 'LoginType';    e = { $_.MemberLoginType } },
+                        @{ n = 'LoadGUID';     e = { $runGUID } },
+                        @{ n = 'CollectedAt';  e = { $collectedAt } }
+
+                    Write-ToCms -Data $roleRows -Table '[Inst].[InstanceRoles]' -Section 'Instance'
+                }
+                catch {
+                    Write-DbaLog "[Instance][InstanceRoles] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Linked Servers -------------------------------------------
+                try {
+                    $linked    = Get-DbaLinkedServer -SqlInstance $instance @credParam -EnableException
+                    $lsRows    = $linked | Select-Object `
+                        @{ n = 'ServerName';    e = { $hostName } },
+                        @{ n = 'InstanceName';  e = { $instance } },
+                        Name,
+                        @{ n = 'DataSource';    e = { $_.DataSource } },
+                        @{ n = 'ProviderName';  e = { $_.ProviderName } },
+                        @{ n = 'ProductName';   e = { $_.ProductName } },
+                        @{ n = 'Collation';     e = { $_.Collation } },
+                        CreateDate,
+                        @{ n = 'LoadGUID';      e = { $runGUID } },
+                        @{ n = 'CollectedAt';   e = { $collectedAt } }
+
+                    Write-ToCms -Data $lsRows -Table '[Inst].[LinkedServers]' -Section 'Instance'
+                }
+                catch {
+                    Write-DbaLog "[Instance][LinkedServers] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Agent Jobs -----------------------------------------------
+                try {
+                    $jobs    = Get-DbaAgentJob -SqlInstance $instance @credParam -EnableException
+                    $jobRows = $jobs | Select-Object `
+                        @{ n = 'ServerName';      e = { $hostName } },
+                        @{ n = 'InstanceName';    e = { $instance } },
+                        Name, Category, IsEnabled,
+                        @{ n = 'OwnerLoginName';  e = { $_.OwnerLoginName } },
+                        @{ n = 'LastRunDate';     e = { $_.LastRunDate } },
+                        @{ n = 'LastRunOutcome';  e = { $_.LastRunOutcome } },
+                        @{ n = 'HasSchedule';     e = { $_.HasSchedule } },
+                        @{ n = 'LoadGUID';        e = { $runGUID } },
+                        @{ n = 'CollectedAt';     e = { $collectedAt } }
+
+                    Write-ToCms -Data $jobRows -Table '[Inst].[Jobs]' -Section 'Instance'
+
+                    $failedRows = $jobs | Where-Object { $_.LastRunOutcome -eq 'Failed' } |
+                        Select-Object `
+                            @{ n = 'ServerName';     e = { $hostName } },
+                            @{ n = 'InstanceName';   e = { $instance } },
+                            Name, Category,
+                            @{ n = 'LastRunDate';    e = { $_.LastRunDate } },
+                            @{ n = 'LoadGUID';       e = { $runGUID } },
+                            @{ n = 'CollectedAt';    e = { $collectedAt } }
+
+                    if ($failedRows) {
+                        Write-ToCms -Data $failedRows -Table '[Inst].[JobsFailed]' -Section 'Instance'
+                    }
+                }
+                catch {
+                    Write-DbaLog "[Instance][Jobs] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                $sectionsDone.Add('Instance')
+            }
+            #endregion Instance
+
+            # =================================================================
+            #region Section: Databases
+            # =================================================================
+            if ($runAll -or $Sections -contains 'Databases') {
+                $stepName = "Databases - $instance"
+
+                # -- Database Properties --------------------------------------
+                try {
+                    $databases = Get-DbaDatabase -SqlInstance $instance @credParam -EnableException
+                    $dbRows    = $databases | Select-Object `
+                        @{ n = 'ServerName';                    e = { $hostName } },
+                        @{ n = 'InstanceName';                  e = { $instance } },
+                        Name, Status, Owner, CreateDate,
+                        @{ n = 'SizeInMB';                      e = { $_.Size } },
+                        @{ n = 'SpaceAvailableInMB';            e = { [math]::Round($_.SpaceAvailable / 1024, 2) } },
+                        @{ n = 'PctFreeSpace';                  e = { if ($_.Size -gt 0) { [math]::Round(($_.SpaceAvailable / 1024) / $_.Size * 100, 2) } else { 0 } } },
+                        RecoveryModel, CompatibilityLevel, Collation,
+                        LastBackupDate, LastDifferentialBackupDate, LastLogBackupDate,
+                        @{ n = 'IsReadCommittedSnapshotOn';     e = { $_.IsReadCommittedSnapshotOn } },
+                        @{ n = 'IsEncrypted';                   e = { $_.EncryptionEnabled } },
+                        @{ n = 'IsMirroringEnabled';            e = { $_.IsMirroringEnabled } },
+                        @{ n = 'AvailabilityGroupName';         e = { $_.AvailabilityGroupName } },
+                        @{ n = 'IsReadOnly';                    e = { $_.ReadOnly } },
+                        AutoShrink,
+                        @{ n = 'BrokerEnabled';                 e = { $_.BrokerEnabled } },
+                        @{ n = 'ChangeTrackingEnabled';         e = { $_.ChangeTrackingEnabled } },
+                        @{ n = 'ActiveConnections';             e = { $_.ActiveConnections } },
+                        @{ n = 'LoadGUID';                      e = { $runGUID } },
+                        @{ n = 'CollectedAt';                   e = { $collectedAt } }
+
+                    Write-ToCms -Data $dbRows -Table '[DB].[DatabaseInfo]' -Section 'Databases'
+                }
+                catch {
+                    Write-DbaLog "[Databases][DatabaseInfo] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Last Good DBCC -------------------------------------------
+                try {
+                    $dbccInfo = Get-DbaLastGoodCheckDb -SqlInstance $instance @credParam -EnableException
+                    $dbccRows = $dbccInfo | Select-Object `
+                        @{ n = 'ServerName';         e = { $hostName } },
+                        @{ n = 'InstanceName';       e = { $instance } },
+                        @{ n = 'DatabaseName';       e = { $_.Database } },
+                        @{ n = 'LastGoodDBCC';       e = { $_.LastGoodCheckDb } },
+                        @{ n = 'DaysSinceLastDBCC';  e = { $_.DaysSinceLastGoodCheckDb } },
+                        @{ n = 'Status';             e = { $_.Status } },
+                        @{ n = 'LoadGUID';           e = { $runGUID } },
+                        @{ n = 'CollectedAt';        e = { $collectedAt } }
+
+                    Write-ToCms -Data $dbccRows -Table '[DB].[LastGoodDBCC]' -Section 'Databases'
+                }
+                catch {
+                    Write-DbaLog "[Databases][LastGoodDBCC] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Database Files -------------------------------------------
+                try {
+                    $dbFiles  = Get-DbaDbFile -SqlInstance $instance @credParam -EnableException
+                    $fileRows = $dbFiles | Select-Object `
+                        @{ n = 'ServerName';     e = { $hostName } },
+                        @{ n = 'InstanceName';   e = { $instance } },
+                        Database, FileGroupName, LogicalName, PhysicalName,
+                        TypeDescription, FileId,
+                        @{ n = 'SizeInMB';       e = { [math]::Round($_.Size.Megabyte, 2) } },
+                        @{ n = 'UsedInMB';       e = { [math]::Round($_.UsedSpace.Megabyte, 2) } },
+                        @{ n = 'GrowthInMB';     e = { if ($_.GrowthType -eq 'KB') { [math]::Round($_.Growth / 1024, 2) } else { $null } } },
+                        @{ n = 'GrowthPct';      e = { if ($_.GrowthType -eq 'Percent') { $_.Growth } else { $null } } },
+                        @{ n = 'GrowthType';     e = { $_.GrowthType } },
+                        @{ n = 'LoadGUID';       e = { $runGUID } },
+                        @{ n = 'CollectedAt';    e = { $collectedAt } }
+
+                    Write-ToCms -Data $fileRows -Table '[DB].[DatabaseFiles]' -Section 'Databases'
+                }
+                catch {
+                    Write-DbaLog "[Databases][DatabaseFiles] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Backup History -------------------------------------------
+                try {
+                    $backups  = Get-DbaDbBackupHistory -SqlInstance $instance @credParam -Last -EnableException
+                    $bakRows  = $backups | Select-Object `
+                        @{ n = 'ServerName';           e = { $hostName } },
+                        @{ n = 'InstanceName';         e = { $instance } },
+                        @{ n = 'DBName';               e = { $_.Database } },
+                        @{ n = 'BackupType';           e = { $_.Type } },
+                        @{ n = 'BackupStartDate';      e = { $_.Start } },
+                        @{ n = 'BackupFinishDate';     e = { $_.End } },
+                        @{ n = 'BackupDurationSec';    e = { $_.Duration.TotalSeconds } },
+                        @{ n = 'BackupSizeGB';         e = { [math]::Round($_.TotalSize / 1GB, 4) } },
+                        @{ n = 'CompressedSizeGB';     e = { [math]::Round($_.CompressedBackupSize / 1GB, 4) } },
+                        @{ n = 'PhysicalDeviceName';   e = { $_.Path } },
+                        @{ n = 'IsCopyOnly';           e = { $_.IsCopyOnly } },
+                        @{ n = 'RecoveryModel';        e = { $_.RecoveryModel } },
+                        @{ n = 'LoadGUID';             e = { $runGUID } },
+                        @{ n = 'CollectedAt';          e = { $collectedAt } }
+
+                    Write-ToCms -Data $bakRows -Table '[DB].[DatabaseBackups]' -Section 'Databases'
+                }
+                catch {
+                    Write-DbaLog "[Databases][DatabaseBackups] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Database Role Members ------------------------------------
+                try {
+                    $roleMembers = Get-DbaDbRoleMember -SqlInstance $instance @credParam -EnableException
+                    $roleRows    = $roleMembers | Select-Object `
+                        @{ n = 'ServerName';   e = { $hostName } },
+                        @{ n = 'InstanceName'; e = { $instance } },
+                        Database, Role, UserName, Login,
+                        @{ n = 'LoadGUID';     e = { $runGUID } },
+                        @{ n = 'CollectedAt';  e = { $collectedAt } }
+
+                    Write-ToCms -Data $roleRows -Table '[DB].[DBUserRoles]' -Section 'Databases'
+                }
+                catch {
+                    Write-DbaLog "[Databases][DBUserRoles] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- User Permissions -----------------------------------------
+                try {
+                    $perms    = Get-DbaUserPermission -SqlInstance $instance @credParam -EnableException
+                    $permRows = $perms | Select-Object `
+                        @{ n = 'ServerName';   e = { $hostName } },
+                        @{ n = 'InstanceName'; e = { $instance } },
+                        Database, Object, Type, Member, RoleSecurableClass,
+                        PermissionName, PermissionState,
+                        @{ n = 'LoadGUID';     e = { $runGUID } },
+                        @{ n = 'CollectedAt';  e = { $collectedAt } }
+
+                    Write-ToCms -Data $permRows -Table '[Tbl].[TblPermissions]' -Section 'Databases'
+                }
+                catch {
+                    Write-DbaLog "[Databases][TblPermissions] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                # -- Missing Indexes ------------------------------------------
+                try {
+                    $missingIdx = Get-DbaDbMissingIndex -SqlInstance $instance @credParam -EnableException
+                    $idxRows    = $missingIdx | Select-Object `
+                        @{ n = 'ServerName';      e = { $hostName } },
+                        @{ n = 'InstanceName';    e = { $instance } },
+                        DatabaseName, SchemaName, TableName,
+                        @{ n = 'EqualityColumns'; e = { $_.EqualityColumns } },
+                        @{ n = 'InEqualColumns';  e = { $_.InequalityColumns } },
+                        @{ n = 'IncludedColumns'; e = { $_.IncludedColumns } },
+                        @{ n = 'AvgUserImpact';   e = { $_.AvgUserImpact } },
+                        @{ n = 'UserSeeks';       e = { $_.UserSeeks } },
+                        @{ n = 'UserScans';       e = { $_.UserScans } },
+                        @{ n = 'LastUserSeek';    e = { $_.LastUserSeek } },
+                        @{ n = 'LoadGUID';        e = { $runGUID } },
+                        @{ n = 'CollectedAt';     e = { $collectedAt } }
+
+                    Write-ToCms -Data $idxRows -Table '[Inst].[MissingIndexes]' -Section 'Databases'
+                }
+                catch {
+                    Write-DbaLog "[Databases][MissingIndexes] $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+
+                $sectionsDone.Add('Databases')
+            }
+            #endregion Databases
+
+            # =================================================================
+            #region Section: HA
+            # =================================================================
+            if ($runAll -or $Sections -contains 'HA') {
+                $stepName = "HA - $instance"
+                try {
+                    $agGroups = Get-DbaAvailabilityGroup -SqlInstance $instance @credParam -EnableException
+
+                    if ($agGroups) {
+                        # AG Groups
+                        $agRows = $agGroups | Select-Object `
+                            @{ n = 'ServerName';        e = { $hostName } },
+                            @{ n = 'InstanceName';      e = { $instance } },
+                            @{ n = 'AGName';            e = { $_.Name } },
+                            @{ n = 'PrimaryReplica';    e = { $_.PrimaryReplicaServerName } },
+                            @{ n = 'SyncHealth';        e = { $_.SynchronizationHealth } },
+                            @{ n = 'BackupPreference';  e = { $_.AutomatedBackupPreference } },
+                            @{ n = 'FailoverMode';      e = { $_.FailureConditionLevel } },
+                            @{ n = 'LoadGUID';          e = { $runGUID } },
+                            @{ n = 'CollectedAt';       e = { $collectedAt } }
+
+                        Write-ToCms -Data $agRows -Table '[DB].[AvailGroups]' -Section 'HA'
+
+                        # AG Replicas
+                        $repRows = $agGroups | ForEach-Object {
+                            $agName = $_.Name
+                            $_.AvailabilityReplicas | Select-Object `
+                                @{ n = 'ServerName';         e = { $hostName } },
+                                @{ n = 'InstanceName';       e = { $instance } },
+                                @{ n = 'AGName';             e = { $agName } },
+                                @{ n = 'ReplicaName';        e = { $_.Name } },
+                                @{ n = 'AvailabilityMode';   e = { $_.AvailabilityMode } },
+                                @{ n = 'FailoverMode';       e = { $_.FailoverMode } },
+                                @{ n = 'ConnectionModeInPrimary';   e = { $_.ConnectionModeInPrimaryRole } },
+                                @{ n = 'ConnectionModeInSecondary'; e = { $_.ConnectionModeInSecondaryRole } },
+                                @{ n = 'BackupPriority';     e = { $_.BackupPriority } },
+                                @{ n = 'EndpointUrl';        e = { $_.EndpointUrl } },
+                                @{ n = 'LoadGUID';           e = { $runGUID } },
+                                @{ n = 'CollectedAt';        e = { $collectedAt } }
+                        }
+
+                        Write-ToCms -Data $repRows -Table '[DB].[AvailReplicas]' -Section 'HA'
+
+                        # AG Databases
+                        $agDbRows = $agGroups | ForEach-Object {
+                            $agName = $_.Name
+                            $_.AvailabilityDatabases | Select-Object `
+                                @{ n = 'ServerName';       e = { $hostName } },
+                                @{ n = 'InstanceName';     e = { $instance } },
+                                @{ n = 'AGName';           e = { $agName } },
+                                @{ n = 'DBName';           e = { $_.Name } },
+                                @{ n = 'SyncState';        e = { $_.SynchronizationState } },
+                                @{ n = 'SyncHealth';       e = { $_.SynchronizationHealth } },
+                                @{ n = 'IsSuspended';      e = { $_.IsSuspended } },
+                                @{ n = 'LoadGUID';         e = { $runGUID } },
+                                @{ n = 'CollectedAt';      e = { $collectedAt } }
+                        }
+
+                        Write-ToCms -Data $agDbRows -Table '[DB].[AvailDatabases]' -Section 'HA'
+                    }
+                    else {
+                        Write-DbaLog "[HA] No Availability Groups found on $instance."
+                    }
+                    $sectionsDone.Add('HA')
+                }
+                catch {
+                    Write-DbaLog "[HA] $($instance) - $($_.Exception.Message)" -Level WARN
+                    $sectionsFailed.Add('HA')
+                }
+            }
+            #endregion HA
+
+            # =================================================================
+            #region Section: SSRS
+            # =================================================================
+            if ($runAll -or $Sections -contains 'SSRS') {
+                $stepName = "SSRS - $instance"
+
+                if (-not $isWindows) {
+                    Write-DbaLog "[SSRS] Skipped for Linux instance $instance." -Level WARN
+                }
+                else {
+                    try {
+                        $ssrsInfo = Get-DbaReportingService -ComputerName $hostName -EnableException
+                        if ($ssrsInfo) {
+                            $ssrsRows = $ssrsInfo | Select-Object `
+                                @{ n = 'ServerName';          e = { $hostName } },
+                                @{ n = 'InstanceName';        e = { $instance } },
+                                ServiceName, DisplayName, State, StartMode,
+                                @{ n = 'ServiceAccount';      e = { $_.StartName } },
+                                @{ n = 'LoadGUID';            e = { $runGUID } },
+                                @{ n = 'CollectedAt';         e = { $collectedAt } }
+
+                            Write-ToCms -Data $ssrsRows -Table '[RS].[SSRSInfo]' -Section 'SSRS'
+                        }
+                        $sectionsDone.Add('SSRS')
+                    }
+                    catch {
+                        Write-DbaLog "[SSRS] $($instance) - $($_.Exception.Message)" -Level WARN
+                        $sectionsFailed.Add('SSRS')
+                    }
+                }
+            }
+            #endregion SSRS
+
+            # =================================================================
+            # Update CMS collection timestamp
+            # =================================================================
+            if ($PSCmdlet.ShouldProcess($instance, 'Update inventory collection timestamp in CentralDB')) {
+                try {
+                    Invoke-DbaQuery `
+                        -SqlInstance    $CMSInstanceName `
+                        -Database       $CMSDatabaseName `
+                        -Query          'EXEC [Svr].[usp_SetCollectionLastRun] @CollectionType = @ct, @ServerName = @sv, @InstanceName = @in, @LoadGUID = @lg' `
+                        -SqlParameters  @{ ct = 'Inventory'; sv = $hostName; in = $instancePart; lg = $runGUID } `
+                        -CommandTimeout $CommandTimeout `
+                        @cmsCredParam   -EnableException
+                }
+                catch {
+                    Write-DbaLog "Failed to update collection timestamp for $($instance) - $($_.Exception.Message)" -Level WARN
+                }
+            }
+
+            Write-DbaLog "=== Completed $instance. Sections done: $($sectionsDone -join ', '). Failed: $($sectionsFailed -join ', ') ==="
+
+            $Script:Results.Add([PSCustomObject]@{
+                PSTypeName       = 'CentralDB.InventoryResult'
+                SqlInstance      = $instance
+                SectionsDone     = $sectionsDone -join ', '
+                SectionsFailed   = $sectionsFailed -join ', '
+                LoadGUID         = $runGUID
+                CollectedAt      = $collectedAt
+                Status           = if ($sectionsFailed.Count -eq 0) { 'Success' } else { 'PartialSuccess' }
+                ErrorMessage     = $null
+            })
+        }
+
+        if ($instanceErrors.Count -gt 0) {
+            $summary = $instanceErrors -join "`n"
+            throw "Get-CentralInventory completed with $($instanceErrors.Count) instance error(s):`n$summary"
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    end {
+        $elapsedTime.Stop()
+        $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+
+        if ($Script:ErrorCount -gt 0) {
+            Write-Warning "Get-CentralInventory completed with $Script:ErrorCount error(s) in $duration."
+        }
+        else {
+            Write-DbaLog "Get-CentralInventory completed successfully in $duration."
+        }
+
+        #region Export Output
+        $exportBase = Join-Path $OutputPath ("Inventory_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss')")
+
+        switch ($OutputFormat) {
+            'CSV'      { $Script:Results | Export-Csv -Path "$exportBase.csv"  -NoTypeInformation }
+            'JSON'     { $Script:Results | ConvertTo-Json -Depth 5 | Out-File -FilePath "$exportBase.json" -Encoding utf8 }
+            'HTML'     { $Script:Results | ConvertTo-Html -Title 'CentralDB Inventory' | Out-File -FilePath "$exportBase.html" -Encoding utf8 }
+            'GridView' { $Script:Results | Out-GridView -Title 'CentralDB Inventory' }
+            'Excel'    {
+                if (Get-Module -Name ImportExcel -ListAvailable) {
+                    $Script:Results | Export-Excel -Path "$exportBase.xlsx" -AutoSize -FreezeTopRow
+                }
+                else {
+                    Write-DbaLog 'ImportExcel not found - falling back to CSV.' -Level WARN
+                    $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation
+                }
+            }
+        }
+
+        Write-DbaLog "Output written to $exportBase.$($OutputFormat.ToLower())"
+        #endregion
+
+        $Script:Results
+    }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION: forwards script params to the function
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') {
+        $invokeParams[$key] = $PSBoundParameters[$key]
+    }
+}
+Get-CentralInventory @invokeParams -Confirm:$false

--- a/Collect/Get-CentralWaitStats.ps1
+++ b/Collect/Get-CentralWaitStats.ps1
@@ -1,0 +1,570 @@
+# ============================================================================
+# PART 1 - Script-level parameter block
+#          Enables: powershell.exe -File Get-CentralWaitStats.ps1 -Param Value
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+param (
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+
+    [Parameter()]
+    [PSCredential]$SqlCredential,
+
+    [Parameter()]
+    [string]$CMSInstanceName,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$CMSDatabaseName = 'CentralDB',
+
+    [Parameter()]
+    [ValidateRange(60, 86400)]
+    [int]$CommandTimeout = 600,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$IntroduceDelay = 'N',
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMin = 1,
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMax = 300,
+
+    [Parameter()]
+    [switch]$RunLocally,
+
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+    [string]$OutputFormat = 'CSV',
+
+    [Parameter()]
+    [string]$LoadGUID,
+
+    [Parameter()]
+    [switch]$IncludeSystemWaits
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Get-CentralWaitStats {
+<#
+.SYNOPSIS
+    Collects wait statistics from one or more SQL Server instances and
+    centralizes the results into [Inst].[WaitStats] in CentralDB.
+
+.DESCRIPTION
+    Replaces the legacy Get-WaitStats.ps1 (SMO + SqlBulkCopy, 2017).
+    Uses dbatools Get-DbaWaitStatistic for collection and Write-DbaDbTableData
+    for centralization.
+
+    Collection behavior:
+    - If -SqlInstance is provided, collects from those instances directly.
+    - If -CMSInstanceName is provided without -SqlInstance, queries
+      [Svr].[usp_GetCollectionTargets] to resolve the target list.
+    - If -RunLocally is specified, restricts CMS discovery to the local
+      machine only (for use in MSX/TSX SQL Agent deployments).
+
+    After each successful collection, calls [Svr].[usp_SetCollectionLastRun]
+    on CentralDB to record the run timestamp. CentralDB write failures are
+    non-fatal (WARN only) and never abort instance processing.
+
+    Each instance is processed independently. A failure on one instance is
+    logged and accumulated; processing continues on remaining instances.
+    The final throw ensures SQL Agent correctly reports job failure.
+
+.PARAMETER SqlInstance
+    One or more SQL Server instance names to collect from.
+    Accepts hostname, hostname\instance, or hostname,port formats.
+    Accepts pipeline input. If omitted, CMS discovery is used.
+
+.PARAMETER SqlCredential
+    PSCredential for SQL Server authentication on target instances.
+    When omitted, Windows authentication is used.
+
+.PARAMETER CMSInstanceName
+    The CentralDB SQL Server instance. Used to resolve the target server
+    list via [Svr].[usp_GetCollectionTargets] when -SqlInstance is not
+    provided. Also the destination for centralized results.
+
+.PARAMETER CMSDatabaseName
+    The CentralDB database name. Default: CentralDB.
+
+.PARAMETER CommandTimeout
+    Query timeout in seconds applied to all dbatools calls. Default: 600.
+    Valid range: 60 - 86400.
+
+.PARAMETER IntroduceDelay
+    Set to 'Y' to introduce a random delay before processing begins.
+    Intended for MSX/TSX jobs where multiple servers run the same job
+    simultaneously and you want to stagger CentralDB writes.
+
+.PARAMETER DelaySecMin
+    Minimum delay in seconds when IntroduceDelay is 'Y'. Default: 1.
+
+.PARAMETER DelaySecMax
+    Maximum delay in seconds when IntroduceDelay is 'Y'. Default: 300.
+
+.PARAMETER RunLocally
+    Restricts CMS discovery to the local machine only. Use this when
+    the script is deployed as a SQL Agent job via MSX/TSX so each target
+    server collects only its own data.
+
+.PARAMETER OutputPath
+    Directory path where the CSV/HTML/JSON output file is written.
+    Must exist before the script runs.
+
+.PARAMETER OutputFormat
+    Format for the output file. Default: CSV.
+    Supported: CSV, HTML, JSON, Excel, GridView.
+
+.PARAMETER LoadGUID
+    Optional correlation GUID. If omitted, a new GUID is generated.
+    Pass the same GUID across multiple collection scripts in a single
+    scheduled run to correlate results in CentralDB.
+
+.PARAMETER IncludeSystemWaits
+    When specified, includes all wait types including typically benign
+    system waits. By default, dbatools filters these out.
+
+.EXAMPLE
+    .\Get-CentralWaitStats.ps1 -SqlInstance 'SQL-01' -CMSInstanceName 'CMS-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run against a single instance. No data is collected or written.
+
+.EXAMPLE
+    .\Get-CentralWaitStats.ps1 -CMSInstanceName 'CMS-01' -RunLocally -OutputPath 'D:\Logs'
+    MSX/TSX mode: resolves instances from CentralDB, restricts to local
+    machine, collects wait stats and centralizes to CMS-01.CentralDB.
+
+.EXAMPLE
+    .\Get-CentralWaitStats.ps1 -CMSInstanceName 'CMS-01' -IntroduceDelay Y -DelaySecMin 5 -DelaySecMax 60 -OutputPath 'D:\Logs'
+    Fleet collection with staggered start to reduce simultaneous CentralDB writes.
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : 2024-01-01
+    Version     : 4.1.0
+    Replaces    : CentralDB/Get-WaitStats.ps1 (legacy SMO + SqlBulkCopy)
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+    Impact      : LOW - read-only on target instances, INSERT on CentralDB
+    Schedule    : Daily via SQL Agent (recommended: 06:00 local time)
+
+    Permissions :
+        Target    : VIEW SERVER STATE on each collected instance
+        CentralDB : EXECUTE on [Svr].[usp_GetCollectionTargets]
+                    EXECUTE on [Svr].[usp_SetCollectionLastRun]
+                    INSERT on [Inst].[WaitStats]
+
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\share\CentralDB\Collect\Get-CentralWaitStats.ps1"
+                        -CMSInstanceName "$(ESCAPE_DQUOTE(SRVR))"
+                        -RunLocally
+                        -OutputPath "D:\Logs\CentralDB"
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [string[]]$SqlInstance,
+
+        [Parameter()]
+        [PSCredential]$SqlCredential,
+
+        [Parameter()]
+        [string]$CMSInstanceName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CMSDatabaseName = 'CentralDB',
+
+        [Parameter()]
+        [ValidateRange(60, 86400)]
+        [int]$CommandTimeout = 600,
+
+        [Parameter()]
+        [ValidateSet('Y', 'N')]
+        [string]$IntroduceDelay = 'N',
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMin = 1,
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMax = 300,
+
+        [Parameter()]
+        [switch]$RunLocally,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Container })]
+        [string]$OutputPath,
+
+        [Parameter()]
+        [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+        [string]$OutputFormat = 'CSV',
+
+        [Parameter()]
+        [string]$LoadGUID,
+
+        [Parameter()]
+        [switch]$IncludeSystemWaits
+    )
+
+    # -------------------------------------------------------------------------
+    begin {
+        #region Module Dependency Check
+        $SCRIPT_VERSION  = '4.1.0'
+        $requiredVersion = [Version]'2.0.0'
+        $dbatoolsMod     = Get-Module -Name dbatools -ListAvailable |
+                               Sort-Object Version -Descending |
+                               Select-Object -First 1
+        if (-not $dbatoolsMod) {
+            throw 'dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers'
+        }
+        if ($dbatoolsMod.Version -lt $requiredVersion) {
+            Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended."
+        }
+        Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+        #endregion
+
+        #region Initialization
+        $ErrorActionPreference = 'Stop'
+        $Script:ErrorCount     = 0
+        $Script:WarningCount   = 0
+        $Script:Results        = New-Object 'System.Collections.Generic.List[PSCustomObject]'
+        $elapsedTime           = [System.Diagnostics.Stopwatch]::StartNew()
+        $stepName              = 'Initialization'
+        $collectedAt           = Get-Date
+
+        if ($LoadGUID) {
+            $runGUID = $LoadGUID
+        }
+        else {
+            $runGUID = [guid]::NewGuid().ToString()
+        }
+        #endregion
+
+        #region Credential Splat
+        $credParam = @{}
+        if ($SqlCredential) { $credParam['SqlCredential'] = $SqlCredential }
+
+        $cmsCredParam = @{}
+        if ($SqlCredential) { $cmsCredParam['SqlCredential'] = $SqlCredential }
+        #endregion
+
+        #region Write-DbaLog Helper
+        function Write-DbaLog {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory)]
+                [string]$Message,
+
+                [Parameter()]
+                [ValidateSet('INFO', 'WARN', 'ERROR', 'DEBUG')]
+                [string]$Level = 'INFO'
+            )
+            $ts    = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            $entry = "[$ts] [$Level] $Message"
+            switch ($Level) {
+                'INFO'  { Write-Verbose $entry }
+                'WARN'  { Write-Warning $entry; $Script:WarningCount++ }
+                'ERROR' { Write-Warning "ERROR: $Message"; $Script:ErrorCount++ }
+                'DEBUG' { Write-Debug $entry }
+            }
+        }
+        #endregion
+
+        #region CMS Connection Test
+        function Test-CMSConnection {
+            try {
+                $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @cmsCredParam -ErrorAction Stop
+                return $true
+            }
+            catch {
+                return $false
+            }
+        }
+        #endregion
+
+        Write-DbaLog "Get-CentralWaitStats v$SCRIPT_VERSION started. LoadGUID: $runGUID"
+
+        #region Stagger Delay
+        if ($IntroduceDelay -eq 'Y') {
+            $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+            Write-DbaLog "Stagger delay: sleeping $delay seconds."
+            Start-Sleep -Seconds $delay
+        }
+        #endregion
+
+        #region Instance Discovery
+        $stepName = 'Instance Discovery'
+        if ($RunLocally) {
+            Write-DbaLog 'RunLocally specified - resolving local instance from CMS.'
+
+            if (-not $CMSInstanceName) {
+                throw '-CMSInstanceName is required when -RunLocally is specified.'
+            }
+
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+
+            $localHost  = $env:COMPUTERNAME
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance $CMSInstanceName `
+                -Database    $CMSDatabaseName `
+                -Query       'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct, @RunLocally = 1, @LocalServerName = @sn' `
+                -SqlParameters @{ ct = 'WaitStats'; sn = $localHost } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam `
+                -EnableException
+
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName
+                $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') {
+                    "$sv\$in"
+                }
+                else {
+                    $sv
+                }
+            })
+            Write-DbaLog "RunLocally resolved $($SqlInstance.Count) instance(s) for $localHost."
+        }
+        elseif ($CMSInstanceName -and (-not $SqlInstance)) {
+            Write-DbaLog "No -SqlInstance provided - resolving from CMS '$CMSInstanceName'."
+
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance $CMSInstanceName `
+                -Database    $CMSDatabaseName `
+                -Query       'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct' `
+                -SqlParameters @{ ct = 'WaitStats' } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam `
+                -EnableException
+
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName
+                $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') {
+                    "$sv\$in"
+                }
+                else {
+                    $sv
+                }
+            })
+            Write-DbaLog "CMS discovery resolved $($SqlInstance.Count) instance(s)."
+        }
+
+        if (-not $SqlInstance -or $SqlInstance.Count -eq 0) {
+            throw 'No target instances resolved. Provide -SqlInstance or configure -CMSInstanceName with registered servers.'
+        }
+        #endregion
+    }
+
+    # -------------------------------------------------------------------------
+    process {
+        $instanceErrors = New-Object 'System.Collections.Generic.List[string]'
+
+        foreach ($instance in $SqlInstance) {
+
+            # Extract hostname for stored proc calls
+            $hostName = ($instance -split '[\\,]')[0]
+
+            $stepName = "Connecting to $instance"
+            Write-DbaLog "Processing $instance"
+
+            try {
+                # ------------------------------------------------------------------
+                $stepName = "Collecting wait statistics from $instance"
+
+                $waitParams = @{
+                    SqlInstance     = $instance
+                    CommandTimeout  = $CommandTimeout
+                    EnableException = $true
+                }
+                if ($SqlCredential)      { $waitParams['SqlCredential']         = $SqlCredential }
+                if ($IncludeSystemWaits) { $waitParams['IncludeIgnorable']      = $true }
+
+                $waitData = Get-DbaWaitStatistic @waitParams
+
+                if (-not $waitData) {
+                    Write-DbaLog "No wait statistics returned from $instance - skipping." -Level WARN
+                    continue
+                }
+
+                # Enrich with metadata required by [Inst].[WaitStats]
+                $enriched = $waitData | Select-Object `
+                    @{ n = 'ServerName';              e = { $hostName } },
+                    @{ n = 'InstanceName';            e = { $instance } },
+                    @{ n = 'WaitType';                e = { $_.WaitType } },
+                    @{ n = 'Category';                e = { $_.Category } },
+                    @{ n = 'Wait_S';                  e = { $_.WaitSeconds } },
+                    @{ n = 'Resource_S';              e = { $_.ResourceSeconds } },
+                    @{ n = 'Signal_S';                e = { $_.SignalSeconds } },
+                    @{ n = 'WaitCount';               e = { $_.WaitCount } },
+                    @{ n = 'Percentage';              e = { $_.Percentage } },
+                    @{ n = 'AvgWait_S';               e = { $_.AverageWaitSeconds } },
+                    @{ n = 'AvgRes_S';                e = { $_.AverageResourceSeconds } },
+                    @{ n = 'AvgSig_S';                e = { $_.AverageSignalSeconds } },
+                    @{ n = 'LoadGUID';                e = { $runGUID } },
+                    @{ n = 'CollectedAt';             e = { $collectedAt } }
+
+                Write-DbaLog "Collected $(@($enriched).Count) wait type(s) from $instance."
+
+                # ------------------------------------------------------------------
+                if ($PSCmdlet.ShouldProcess($instance, 'Write wait statistics to CentralDB')) {
+
+                    $stepName = "Writing wait statistics from $instance to CentralDB"
+                    try {
+                        $enriched | Write-DbaDbTableData `
+                            -SqlInstance $CMSInstanceName `
+                            -Database    $CMSDatabaseName `
+                            -Table       '[Inst].[WaitStats]' `
+                            -AutoCreateTable `
+                            @cmsCredParam `
+                            -EnableException
+
+                        Write-DbaLog "Centralized $(@($enriched).Count) row(s) from $instance."
+                    }
+                    catch {
+                        Write-DbaLog "CMS write failed for $instance - $($_.Exception.Message)" -Level WARN
+                        # Non-fatal: CMS failure must never kill the script
+                    }
+
+                    # ------------------------------------------------------------------
+                    $stepName = "Updating collection timestamp for $instance in CentralDB"
+                    try {
+                        $instPart = if ($instance -match '\\') { ($instance -split '\\')[1] } else { 'MSSQLSERVER' }
+
+                        Invoke-DbaQuery `
+                            -SqlInstance $CMSInstanceName `
+                            -Database    $CMSDatabaseName `
+                            -Query       'EXEC [Svr].[usp_SetCollectionLastRun] @CollectionType = @ct, @ServerName = @sv, @InstanceName = @in, @LoadGUID = @lg' `
+                            -SqlParameters @{
+                                ct = 'WaitStats'
+                                sv = $hostName
+                                in = $instPart
+                                lg = $runGUID
+                            } `
+                            -CommandTimeout $CommandTimeout `
+                            @cmsCredParam `
+                            -EnableException
+                    }
+                    catch {
+                        Write-DbaLog "Failed to update collection timestamp for $instance - $($_.Exception.Message)" -Level WARN
+                        # Non-fatal
+                    }
+                }
+
+                # ------------------------------------------------------------------
+                $Script:Results.Add([PSCustomObject]@{
+                    PSTypeName      = 'CentralDB.WaitStatsResult'
+                    SqlInstance     = $instance
+                    RowsCollected   = @($enriched).Count
+                    LoadGUID        = $runGUID
+                    CollectedAt     = $collectedAt
+                    Status          = 'Success'
+                    ErrorMessage    = $null
+                })
+
+            }
+            catch {
+                $msg = "[$($stepName)] Failed on $($instance) - $($_.Exception.Message)"
+                $instanceErrors.Add($msg)
+                Write-DbaLog $msg -Level ERROR
+
+                $Script:Results.Add([PSCustomObject]@{
+                    PSTypeName      = 'CentralDB.WaitStatsResult'
+                    SqlInstance     = $instance
+                    RowsCollected   = 0
+                    LoadGUID        = $runGUID
+                    CollectedAt     = $collectedAt
+                    Status          = 'Failed'
+                    ErrorMessage    = $_.Exception.Message
+                })
+
+                continue
+            }
+        }
+
+        # CRITICAL: throw aggregated errors so SQL Agent sees FAILURE
+        if ($instanceErrors.Count -gt 0) {
+            $summary = $instanceErrors -join "`n"
+            throw "Get-CentralWaitStats completed with $($instanceErrors.Count) error(s):`n$summary"
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    end {
+        $elapsedTime.Stop()
+        $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+
+        if ($Script:ErrorCount -gt 0) {
+            Write-Warning "Get-CentralWaitStats completed with $Script:ErrorCount error(s) in $duration. Review log."
+        }
+        else {
+            Write-DbaLog "Get-CentralWaitStats completed successfully in $duration."
+        }
+
+        #region Export Output
+        $exportFile = Join-Path $OutputPath ("WaitStats_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').$($OutputFormat.ToLower())")
+
+        switch ($OutputFormat) {
+            'CSV'      {
+                $Script:Results | Export-Csv -Path $exportFile -NoTypeInformation
+            }
+            'JSON'     {
+                $Script:Results | ConvertTo-Json -Depth 5 | Out-File -FilePath $exportFile -Encoding utf8
+            }
+            'HTML'     {
+                $Script:Results |
+                    ConvertTo-Html -Title 'CentralDB Wait Stats Collection' |
+                    Out-File -FilePath $exportFile -Encoding utf8
+            }
+            'GridView' {
+                $Script:Results | Out-GridView -Title 'CentralDB Wait Stats Collection'
+            }
+            'Excel'    {
+                if (Get-Module -Name ImportExcel -ListAvailable) {
+                    $Script:Results | Export-Excel -Path $exportFile -AutoSize -FreezeTopRow
+                }
+                else {
+                    Write-DbaLog 'ImportExcel module not found - falling back to CSV.' -Level WARN
+                    $Script:Results | Export-Csv -Path ($exportFile -replace '\.excel$', '.csv') -NoTypeInformation
+                }
+            }
+        }
+
+        Write-DbaLog "Output written to $exportFile"
+        #endregion
+
+        # Emit results to pipeline
+        $Script:Results
+    }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION: forwards script params to the function
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') {
+        $invokeParams[$key] = $PSBoundParameters[$key]
+    }
+}
+Get-CentralWaitStats @invokeParams -Confirm:$false

--- a/Collect/Invoke-CentralBackup.ps1
+++ b/Collect/Invoke-CentralBackup.ps1
@@ -1,0 +1,507 @@
+# ============================================================================
+# PART 1 - Script-level parameter block
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+param (
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+
+    [Parameter()]
+    [PSCredential]$SqlCredential,
+
+    [Parameter()]
+    [string]$CMSInstanceName,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$CMSDatabaseName = 'CentralDB',
+
+    [Parameter()]
+    [ValidateRange(60, 86400)]
+    [int]$CommandTimeout = 14400,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$IntroduceDelay = 'N',
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMin = 1,
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMax = 300,
+
+    [Parameter()]
+    [switch]$RunLocally,
+
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+    [string]$OutputFormat = 'CSV',
+
+    [Parameter()]
+    [string]$LoadGUID,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$DeployOla = 'N',
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$OlaDatabase = 'master',
+
+    [Parameter()]
+    [ValidateSet('FULL', 'DIFF', 'LOG')]
+    [string]$BackupType = 'FULL',
+
+    [Parameter()]
+    [string]$Databases = 'ALL_DATABASES',
+
+    [Parameter()]
+    [string]$Directory,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$Verify = 'Y',
+
+    [Parameter()]
+    [int]$CleanupTime,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$Compress = 'Y',
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$CopyOnly = 'N',
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$CheckSum = 'N',
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$Encrypt = 'N',
+
+    [Parameter()]
+    [ValidateSet('AES128', 'AES192', 'AES256', 'TRIPLE_DES_3KEY')]
+    [string]$EncryptionAlgorithm,
+
+    [Parameter()]
+    [string]$ServerCertificate,
+
+    [Parameter()]
+    [string]$AvailabilityGroups,
+
+    [Parameter()]
+    [ValidateSet('ALL', 'PRIMARY', 'SECONDARY', 'PREFERRED_BACKUP_REPLICA')]
+    [string]$Updateability = 'ALL'
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Invoke-CentralBackup {
+<#
+.SYNOPSIS
+    Executes Ola Hallengren DatabaseBackup against one or more SQL Server
+    instances and centralizes the CommandLog results into CentralDB.
+
+.DESCRIPTION
+    Replaces the legacy Get-OlaHallengren-Backup.ps1 (raw SqlClient, 2017).
+
+    Two phases per instance:
+
+    Deploy (optional, -DeployOla Y):
+      Calls Install-DbaMaintenanceSolution to install or update Ola
+      Hallengren's maintenance solution. Downloads from GitHub.
+
+    Execute and Collect:
+      Calls Ola's DatabaseBackup stored procedure via Invoke-DbaQuery
+      with @LogToTable = 'Y'. After execution, queries the CommandLog
+      table filtered by LoadGUID, centralizes results to [Inst].[CommandLog]
+      in CentralDB, then cleans up the local CommandLog rows.
+
+    CentralDB write failures are non-fatal (WARN only).
+
+.PARAMETER SqlInstance
+    Target SQL Server instances. Accepts pipeline input.
+
+.PARAMETER SqlCredential
+    PSCredential for SQL Server authentication.
+
+.PARAMETER CMSInstanceName
+    CentralDB instance for target discovery and result storage.
+
+.PARAMETER CMSDatabaseName
+    CentralDB database name. Default: CentralDB.
+
+.PARAMETER CommandTimeout
+    Query timeout in seconds. Default: 14400 (4 hours). Backups can run
+    for a long time on large databases.
+
+.PARAMETER IntroduceDelay
+    Set to 'Y' to sleep a random interval before processing.
+
+.PARAMETER DelaySecMin
+    Minimum stagger delay in seconds. Default: 1.
+
+.PARAMETER DelaySecMax
+    Maximum stagger delay in seconds. Default: 300.
+
+.PARAMETER RunLocally
+    Restricts CMS discovery to the local machine only.
+
+.PARAMETER OutputPath
+    Directory for exported output files. Must already exist.
+
+.PARAMETER OutputFormat
+    Output format. Default: CSV.
+
+.PARAMETER LoadGUID
+    Correlation GUID. Generated automatically when omitted.
+
+.PARAMETER DeployOla
+    Set to 'Y' to install/update Ola's solution before running. Default: 'N'.
+
+.PARAMETER OlaDatabase
+    Database where Ola's solution is installed. Default: master.
+
+.PARAMETER BackupType
+    Backup type: FULL, DIFF, or LOG. Default: FULL.
+
+.PARAMETER Databases
+    Ola @Databases parameter. Default: ALL_DATABASES.
+    Supports: ALL_DATABASES, USER_DATABASES, SYSTEM_DATABASES, or a
+    comma-separated list of database names.
+
+.PARAMETER Directory
+    Backup destination directory. Passed to Ola @Directory.
+
+.PARAMETER Verify
+    Verify backup after completion. Y or N. Default: Y.
+
+.PARAMETER CleanupTime
+    Hours after which old backup files are deleted. Passed to Ola @CleanupTime.
+
+.PARAMETER Compress
+    Enable backup compression. Y or N. Default: Y.
+
+.PARAMETER CopyOnly
+    Take a copy-only backup. Y or N. Default: N.
+
+.PARAMETER CheckSum
+    Enable backup checksum. Y or N. Default: N.
+
+.PARAMETER Encrypt
+    Enable backup encryption. Y or N. Default: N.
+
+.PARAMETER EncryptionAlgorithm
+    Encryption algorithm when Encrypt = Y. Options: AES128, AES192, AES256,
+    TRIPLE_DES_3KEY.
+
+.PARAMETER ServerCertificate
+    Server certificate name for encryption.
+
+.PARAMETER AvailabilityGroups
+    Ola @AvailabilityGroups filter.
+
+.PARAMETER Updateability
+    Which AG replicas to back up. Default: ALL.
+
+.EXAMPLE
+    .\Invoke-CentralBackup.ps1 -SqlInstance 'SQL-01' -BackupType FULL -Directory 'E:\Backups' -CMSInstanceName 'CMS-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run of a full backup. No backup is taken.
+
+.EXAMPLE
+    .\Invoke-CentralBackup.ps1 -CMSInstanceName 'CMS-01' -RunLocally -BackupType FULL -Directory 'E:\Backups' -OutputPath 'D:\Logs'
+    MSX/TSX mode: full backup of all databases on the local instance.
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : 2024-01-01
+    Version     : 4.1.0
+    Replaces    : CentralDB/Get-OlaHallengren-Backup.ps1
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+                  Ola Hallengren maintenance solution (or -DeployOla Y)
+    Impact      : HIGH - executes database backups
+    Schedule    : Daily via SQL Agent
+
+    Permissions :
+        Target    : sysadmin or db_backupoperator + VIEW SERVER STATE
+        CentralDB : EXECUTE on [Svr].[usp_GetCollectionTargets]
+                    EXECUTE on [Svr].[usp_SetCollectionLastRun]
+                    INSERT on [Inst].[CommandLog]
+
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\share\CentralDB\Collect\Invoke-CentralBackup.ps1"
+                        -CMSInstanceName "$(ESCAPE_DQUOTE(SRVR))"
+                        -RunLocally -BackupType FULL -Directory "E:\Backups"
+                        -OutputPath "D:\Logs\CentralDB"
+
+    Attribution:
+        DatabaseBackup is created and maintained by Ola Hallengren.
+        https://ola.hallengren.com
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [string[]]$SqlInstance,
+        [Parameter()][PSCredential]$SqlCredential,
+        [Parameter()][string]$CMSInstanceName,
+        [Parameter()][ValidateNotNullOrEmpty()][string]$CMSDatabaseName = 'CentralDB',
+        [Parameter()][ValidateRange(60, 86400)][int]$CommandTimeout = 14400,
+        [Parameter()][ValidateSet('Y', 'N')][string]$IntroduceDelay = 'N',
+        [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMin = 1,
+        [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMax = 300,
+        [Parameter()][switch]$RunLocally,
+        [Parameter(Mandatory)][ValidateScript({ Test-Path $_ -PathType Container })][string]$OutputPath,
+        [Parameter()][ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')][string]$OutputFormat = 'CSV',
+        [Parameter()][string]$LoadGUID,
+        [Parameter()][ValidateSet('Y', 'N')][string]$DeployOla = 'N',
+        [Parameter()][ValidateNotNullOrEmpty()][string]$OlaDatabase = 'master',
+        [Parameter()][ValidateSet('FULL', 'DIFF', 'LOG')][string]$BackupType = 'FULL',
+        [Parameter()][string]$Databases = 'ALL_DATABASES',
+        [Parameter()][string]$Directory,
+        [Parameter()][ValidateSet('Y', 'N')][string]$Verify = 'Y',
+        [Parameter()][int]$CleanupTime,
+        [Parameter()][ValidateSet('Y', 'N')][string]$Compress = 'Y',
+        [Parameter()][ValidateSet('Y', 'N')][string]$CopyOnly = 'N',
+        [Parameter()][ValidateSet('Y', 'N')][string]$CheckSum = 'N',
+        [Parameter()][ValidateSet('Y', 'N')][string]$Encrypt = 'N',
+        [Parameter()][ValidateSet('AES128', 'AES192', 'AES256', 'TRIPLE_DES_3KEY')][string]$EncryptionAlgorithm,
+        [Parameter()][string]$ServerCertificate,
+        [Parameter()][string]$AvailabilityGroups,
+        [Parameter()][ValidateSet('ALL', 'PRIMARY', 'SECONDARY', 'PREFERRED_BACKUP_REPLICA')][string]$Updateability = 'ALL'
+    )
+
+    begin {
+        #region Module Check
+        $SCRIPT_VERSION  = '4.1.0'
+        $requiredVersion = [Version]'2.0.0'
+        $dbatoolsMod     = Get-Module -Name dbatools -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+        if (-not $dbatoolsMod)                        { throw 'dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers' }
+        if ($dbatoolsMod.Version -lt $requiredVersion){ Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended." }
+        Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+        #endregion
+
+        #region Init
+        $ErrorActionPreference = 'Stop'
+        $Script:ErrorCount     = 0
+        $Script:WarningCount   = 0
+        $Script:Results        = New-Object 'System.Collections.Generic.List[PSCustomObject]'
+        $elapsedTime           = [System.Diagnostics.Stopwatch]::StartNew()
+        $stepName              = 'Initialization'
+        $collectedAt           = Get-Date
+        if ($LoadGUID) { $runGUID = $LoadGUID } else { $runGUID = [guid]::NewGuid().ToString() }
+        $credParam    = @{}; if ($SqlCredential) { $credParam['SqlCredential']    = $SqlCredential }
+        $cmsCredParam = @{}; if ($SqlCredential) { $cmsCredParam['SqlCredential'] = $SqlCredential }
+        #endregion
+
+        #region Helpers
+        function Write-DbaLog {
+            param([Parameter(Mandatory)][string]$Message, [ValidateSet('INFO','WARN','ERROR','DEBUG')][string]$Level = 'INFO')
+            $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            switch ($Level) {
+                'INFO'  { Write-Verbose  "[$ts] [INFO]  $Message" }
+                'WARN'  { Write-Warning  "[$ts] [WARN]  $Message"; $Script:WarningCount++ }
+                'ERROR' { Write-Warning  "[$ts] [ERROR] $Message"; $Script:ErrorCount++ }
+                'DEBUG' { Write-Debug    "[$ts] [DEBUG] $Message" }
+            }
+        }
+        function Write-ToCms {
+            param([Parameter(Mandatory)][object]$Data, [Parameter(Mandatory)][string]$Table, [Parameter(Mandatory)][string]$Label)
+            try {
+                $Data | Write-DbaDbTableData -SqlInstance $CMSInstanceName -Database $CMSDatabaseName -Table $Table -AutoCreateTable @cmsCredParam -EnableException
+                Write-DbaLog "[$Label] Wrote $(@($Data).Count) row(s) to $Table"
+            }
+            catch { Write-DbaLog "[$Label] CMS write to $Table failed - $($_.Exception.Message)" -Level WARN } # Non-fatal
+        }
+        function Test-CMSConnection {
+            try { $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @cmsCredParam -ErrorAction Stop; return $true }
+            catch { return $false }
+        }
+        #endregion
+
+        Write-DbaLog "Invoke-CentralBackup v$SCRIPT_VERSION started. LoadGUID: $runGUID | Type: $BackupType"
+
+        if ($IntroduceDelay -eq 'Y') {
+            $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+            Write-DbaLog "Stagger delay: $delay seconds."; Start-Sleep -Seconds $delay
+        }
+
+        #region Instance Discovery
+        $stepName = 'Instance Discovery'
+        if ($RunLocally) {
+            if (-not $CMSInstanceName) { throw '-CMSInstanceName is required when -RunLocally is specified.' }
+            if (-not (Test-CMSConnection)) { throw "CMS instance '$CMSInstanceName' is not reachable." }
+            $localHost = $env:COMPUTERNAME
+            $rows = Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                -Query 'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct, @RunLocally = 1, @LocalServerName = @sn' `
+                -SqlParameters @{ ct = 'Baseline'; sn = $localHost } -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+            $SqlInstance = @($rows | ForEach-Object { $sv=$_.ServerName; $in=$_.InstanceName; if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv } })
+        }
+        elseif ($CMSInstanceName -and (-not $SqlInstance)) {
+            if (-not (Test-CMSConnection)) { throw "CMS instance '$CMSInstanceName' is not reachable." }
+            $rows = Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                -Query 'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct' `
+                -SqlParameters @{ ct = 'Baseline' } -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+            $SqlInstance = @($rows | ForEach-Object { $sv=$_.ServerName; $in=$_.InstanceName; if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv } })
+        }
+        if (-not $SqlInstance -or $SqlInstance.Count -eq 0) { throw 'No target instances resolved.' }
+        #endregion
+    }
+
+    process {
+        $instanceErrors = New-Object 'System.Collections.Generic.List[string]'
+
+        foreach ($instance in $SqlInstance) {
+            $hostName     = ($instance -split '[\\,]')[0]
+            $instancePart = if ($instance -match '\\') { ($instance -split '\\')[1] } else { 'MSSQLSERVER' }
+            Write-DbaLog "=== Begin backup: $instance ($BackupType) ==="
+
+            try {
+                # Phase 1: Optional deploy
+                if ($DeployOla -eq 'Y') {
+                    $stepName = "Deploy Ola on $instance"
+                    if ($PSCmdlet.ShouldProcess($instance, 'Install/update Ola Hallengren maintenance solution')) {
+                        try {
+                            Install-DbaMaintenanceSolution -SqlInstance $instance -Database $OlaDatabase @credParam -EnableException | Out-Null
+                            Write-DbaLog "[Deploy] Ola installed/updated on $instance.$OlaDatabase"
+                        }
+                        catch { Write-DbaLog "[Deploy] Failed on $($instance) - $($_.Exception.Message)" -Level WARN }
+                    }
+                }
+
+                # Phase 2: Verify DatabaseBackup exists
+                $stepName = "Verify DatabaseBackup on $instance"
+                $procCheck = Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                    -Query "SELECT COUNT(1) AS Cnt FROM sys.objects WHERE name = 'DatabaseBackup' AND type = 'P'" `
+                    -CommandTimeout 60 @credParam -EnableException
+                if ($procCheck.Cnt -eq 0) {
+                    Write-DbaLog "[Backup] DatabaseBackup proc not found on $instance.$OlaDatabase. Use -DeployOla Y." -Level WARN
+                    $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.BackupResult'; SqlInstance=$instance; BackupType=$BackupType; RowsCollected=0; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Skipped'; ErrorMessage="DatabaseBackup not found on $OlaDatabase" })
+                    continue
+                }
+
+                # Phase 3: Build and execute DatabaseBackup
+                $stepName = "Execute DatabaseBackup on $instance"
+                if ($PSCmdlet.ShouldProcess($instance, "Execute DatabaseBackup ($BackupType, $Databases)")) {
+
+                    # Build parameter string - only include non-null/non-default values
+                    $olaParams  = "@Databases = '$Databases', @BackupType = '$BackupType', @LogToTable = 'Y', @Execute = 'Y'"
+                    $olaParams += ", @LoadGUID = '$runGUID'"
+                    if ($Directory)            { $olaParams += ", @Directory = '$Directory'" }
+                    if ($Verify)               { $olaParams += ", @Verify = '$Verify'" }
+                    if ($CleanupTime)          { $olaParams += ", @CleanupTime = $CleanupTime" }
+                    if ($Compress)             { $olaParams += ", @Compress = '$Compress'" }
+                    if ($CopyOnly -eq 'Y')     { $olaParams += ", @CopyOnly = 'Y'" }
+                    if ($CheckSum -eq 'Y')     { $olaParams += ", @CheckSum = 'Y'" }
+                    if ($Encrypt -eq 'Y')      { $olaParams += ", @Encrypt = 'Y'" }
+                    if ($EncryptionAlgorithm)  { $olaParams += ", @EncryptionAlgorithm = '$EncryptionAlgorithm'" }
+                    if ($ServerCertificate)    { $olaParams += ", @ServerCertificate = '$ServerCertificate'" }
+                    if ($AvailabilityGroups)   { $olaParams += ", @AvailabilityGroups = '$AvailabilityGroups'" }
+                    if ($Updateability -ne 'ALL') { $olaParams += ", @Updateability = '$Updateability'" }
+
+                    # No SqlParameters here - Ola proc has its own param parsing for the @Databases syntax
+                    # which cannot be passed through sp_executesql parameters
+                    Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                        -Query "EXEC dbo.DatabaseBackup $olaParams" `
+                        -CommandTimeout $CommandTimeout @credParam -EnableException | Out-Null
+                    Write-DbaLog "[Backup] DatabaseBackup completed on $instance"
+
+                    # Phase 4: Collect CommandLog and centralize
+                    $stepName = "Collect CommandLog from $instance"
+                    $logRows = Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                        -Query 'SELECT * FROM dbo.CommandLog WHERE LoadGUID = @lg' `
+                        -SqlParameters @{ lg = $runGUID } `
+                        -CommandTimeout 60 @credParam -EnableException
+
+                    if ($logRows) {
+                        $enriched = $logRows | Select-Object `
+                            @{ n='CollectionServerName'; e={ $hostName } },
+                            @{ n='CollectionInstance';   e={ $instance } },
+                            @{ n='LoadGUID';             e={ $runGUID } },
+                            @{ n='CollectedAt';          e={ $collectedAt } },
+                            *
+                        Write-ToCms -Data $enriched -Table '[Inst].[CommandLog]' -Label 'Backup'
+                    }
+
+                    # Phase 5: Clean up local CommandLog
+                    $stepName = "Clean up CommandLog on $instance"
+                    try {
+                        Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                            -Query 'DELETE FROM dbo.CommandLog WHERE LoadGUID = @lg' `
+                            -SqlParameters @{ lg = $runGUID } `
+                            -CommandTimeout 60 @credParam -EnableException | Out-Null
+                        Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                            -Query 'DELETE FROM dbo.CommandLog WHERE EndTime <= DATEADD(DAY, -1, GETDATE())' `
+                            -CommandTimeout 60 @credParam -EnableException | Out-Null
+                    }
+                    catch { Write-DbaLog "[Backup] CommandLog cleanup failed on $($instance) - $($_.Exception.Message)" -Level WARN }
+
+                    $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.BackupResult'; SqlInstance=$instance; BackupType=$BackupType; RowsCollected=@($logRows).Count; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Success'; ErrorMessage=$null })
+                }
+
+                # Update CMS timestamp
+                try {
+                    Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                        -Query 'EXEC [Svr].[usp_SetCollectionLastRun] @CollectionType = @ct, @ServerName = @sv, @InstanceName = @in, @LoadGUID = @lg' `
+                        -SqlParameters @{ ct='Baseline'; sv=$hostName; in=$instancePart; lg=$runGUID } `
+                        -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+                }
+                catch { Write-DbaLog "Failed to update collection timestamp for $($instance) - $($_.Exception.Message)" -Level WARN }
+
+                Write-DbaLog "=== Completed $instance ==="
+            }
+            catch {
+                $msg = "[$($stepName)] Failed on $($instance) - $($_.Exception.Message)"
+                $instanceErrors.Add($msg)
+                Write-DbaLog $msg -Level ERROR
+                $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.BackupResult'; SqlInstance=$instance; BackupType=$BackupType; RowsCollected=0; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Failed'; ErrorMessage=$_.Exception.Message })
+                continue
+            }
+        }
+
+        if ($instanceErrors.Count -gt 0) {
+            throw "Invoke-CentralBackup completed with $($instanceErrors.Count) instance error(s):`n$($instanceErrors -join "`n")"
+        }
+    }
+
+    end {
+        $elapsedTime.Stop()
+        $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+        if ($Script:ErrorCount -gt 0) { Write-Warning "Invoke-CentralBackup completed with $Script:ErrorCount error(s) in $duration." }
+        else { Write-DbaLog "Invoke-CentralBackup completed successfully in $duration." }
+
+        $exportBase = Join-Path $OutputPath ("Backup_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss')")
+        switch ($OutputFormat) {
+            'CSV'      { $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation }
+            'JSON'     { $Script:Results | ConvertTo-Json -Depth 5 | Out-File -FilePath "$exportBase.json" -Encoding utf8 }
+            'HTML'     { $Script:Results | ConvertTo-Html -Title 'CentralDB Backup' | Out-File -FilePath "$exportBase.html" -Encoding utf8 }
+            'GridView' { $Script:Results | Out-GridView -Title 'CentralDB Backup' }
+            'Excel'    {
+                if (Get-Module -Name ImportExcel -ListAvailable) { $Script:Results | Export-Excel -Path "$exportBase.xlsx" -AutoSize -FreezeTopRow }
+                else { Write-DbaLog 'ImportExcel not found - falling back to CSV.' -Level WARN; $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation }
+            }
+        }
+        Write-DbaLog "Output written to $exportBase.$($OutputFormat.ToLower())"
+        $Script:Results
+    }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') { $invokeParams[$key] = $PSBoundParameters[$key] }
+}
+Invoke-CentralBackup @invokeParams -Confirm:$false

--- a/Collect/Invoke-CentralBlitzCollection.ps1
+++ b/Collect/Invoke-CentralBlitzCollection.ps1
@@ -1,0 +1,627 @@
+# ============================================================================
+# PART 1 - Script-level parameter block
+#          Enables: powershell.exe -File Invoke-CentralBlitzCollection.ps1 -Param Value
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+param (
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+
+    [Parameter()]
+    [PSCredential]$SqlCredential,
+
+    [Parameter()]
+    [string]$CMSInstanceName,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$CMSDatabaseName = 'CentralDB',
+
+    [Parameter()]
+    [ValidateRange(60, 86400)]
+    [int]$CommandTimeout = 600,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$IntroduceDelay = 'N',
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMin = 1,
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMax = 300,
+
+    [Parameter()]
+    [switch]$RunLocally,
+
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+    [string]$OutputFormat = 'CSV',
+
+    [Parameter()]
+    [string]$LoadGUID,
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$DeployFRK = 'N',
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$FRKDatabase = 'master',
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$CheckProcedureCache = 'N',
+
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$CheckUserDatabaseObjects = 'Y'
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Invoke-CentralBlitzCollection {
+<#
+.SYNOPSIS
+    Runs sp_Blitz against one or more SQL Server instances and centralizes
+    the findings into [FRK].[Blitz] in CentralDB.
+
+.DESCRIPTION
+    Replaces the legacy Get-FRKBlitz.ps1 (raw SqlClient + dot-sourced helpers,
+    2017). Uses dbatools throughout.
+
+    Two phases per instance:
+
+    Deploy (optional, -DeployFRK Y):
+      Calls Install-DbaFirstResponderKit to install or update sp_Blitz on the
+      target instance. Downloads the latest release from GitHub. When omitted
+      or set to 'N', the existing installed version is used. If sp_Blitz is
+      not found and DeployFRK is 'N', the instance is skipped with a warning.
+
+    Collect:
+      Executes sp_Blitz via Invoke-DbaQuery and captures the result set
+      directly - no temporary output table round-trip. Enriches each row
+      with ServerName, InstanceName, LoadGUID, and CollectedAt metadata,
+      then writes to [FRK].[Blitz] via Write-DbaDbTableData.
+
+    CentralDB write failures are non-fatal (WARN only).
+    Per-instance errors are accumulated and thrown at the end so SQL Agent
+    correctly reports job failure.
+
+.PARAMETER SqlInstance
+    One or more SQL Server instance names. Accepts pipeline input.
+    If omitted, CMS discovery via -CMSInstanceName is used.
+
+.PARAMETER SqlCredential
+    PSCredential for SQL Server authentication. Required for Linux targets.
+
+.PARAMETER CMSInstanceName
+    The CentralDB instance. Used for target discovery and result storage.
+
+.PARAMETER CMSDatabaseName
+    CentralDB database name. Default: CentralDB.
+
+.PARAMETER CommandTimeout
+    Query timeout in seconds. Default: 600. Range: 60-86400.
+    sp_Blitz with CheckProcedureCache enabled can run for several minutes
+    on busy instances - consider increasing to 1800 for first runs.
+
+.PARAMETER IntroduceDelay
+    Set to 'Y' to sleep a random interval before processing.
+    Use in MSX/TSX jobs to stagger simultaneous CentralDB writes.
+
+.PARAMETER DelaySecMin
+    Minimum stagger delay in seconds. Default: 1.
+
+.PARAMETER DelaySecMax
+    Maximum stagger delay in seconds. Default: 300.
+
+.PARAMETER RunLocally
+    Restricts CMS discovery to the local machine only.
+
+.PARAMETER OutputPath
+    Directory for exported output files. Must already exist.
+
+.PARAMETER OutputFormat
+    Output format. Default: CSV.
+
+.PARAMETER LoadGUID
+    Correlation GUID. Generated automatically when omitted.
+
+.PARAMETER DeployFRK
+    Set to 'Y' to install or update sp_Blitz before running.
+    Uses Install-DbaFirstResponderKit (downloads from GitHub).
+    Default: 'N' - uses the existing installed version.
+
+.PARAMETER FRKDatabase
+    Database where sp_Blitz is installed. Default: master.
+    The original used tempdb; master is the recommended location
+    as tempdb objects are lost on restart.
+
+.PARAMETER CheckProcedureCache
+    Set to 'Y' to enable sp_Blitz procedure cache analysis
+    (@CheckProcedureCache = 1, @OutputProcedureCache = 1).
+    Increases runtime significantly on busy instances. Default: 'N'.
+
+.PARAMETER CheckUserDatabaseObjects
+    Set to 'Y' to check user database objects in sp_Blitz
+    (@CheckUserDatabaseObjects = 1). Default: 'Y'.
+
+.EXAMPLE
+    .\Invoke-CentralBlitzCollection.ps1 -SqlInstance 'SQL-01' -CMSInstanceName 'CMS-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run. No sp_Blitz execution, no CentralDB writes.
+
+.EXAMPLE
+    .\Invoke-CentralBlitzCollection.ps1 -CMSInstanceName 'CMS-01' -RunLocally -DeployFRK Y -OutputPath 'D:\Logs'
+    MSX/TSX mode: updates sp_Blitz then runs it on the local machine.
+
+.EXAMPLE
+    .\Invoke-CentralBlitzCollection.ps1 -SqlInstance '10.0.1.196','10.0.1.129' -SqlCredential $cred -CMSInstanceName 'localhost' -FRKDatabase 'master' -OutputPath 'D:\Logs'
+    Run sp_Blitz against two Linux instances using SQL auth.
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : 2024-01-01
+    Version     : 4.1.0
+    Replaces    : CentralDB/Get-FRKBlitz.ps1 (legacy raw SqlClient)
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+    Impact      : MEDIUM - installs stored procedures when DeployFRK=Y
+    Schedule    : Weekly via SQL Agent (recommended: Sunday 04:00)
+
+    Permissions :
+        Target    : sysadmin or db_owner on FRKDatabase (for sp_Blitz)
+                    VIEW SERVER STATE (for sp_Blitz health checks)
+        CentralDB : EXECUTE on [Svr].[usp_GetCollectionTargets]
+                    EXECUTE on [Svr].[usp_SetCollectionLastRun]
+                    INSERT on [FRK].[Blitz]
+
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\share\CentralDB\Collect\Invoke-CentralBlitzCollection.ps1"
+                        -CMSInstanceName "$(ESCAPE_DQUOTE(SRVR))"
+                        -RunLocally
+                        -OutputPath "D:\Logs\CentralDB"
+
+    Attribution:
+        sp_Blitz is created and maintained by Brent Ozar Unlimited.
+        https://www.brentozar.com/blitz/
+        https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [string[]]$SqlInstance,
+
+        [Parameter()]
+        [PSCredential]$SqlCredential,
+
+        [Parameter()]
+        [string]$CMSInstanceName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CMSDatabaseName = 'CentralDB',
+
+        [Parameter()]
+        [ValidateRange(60, 86400)]
+        [int]$CommandTimeout = 600,
+
+        [Parameter()]
+        [ValidateSet('Y', 'N')]
+        [string]$IntroduceDelay = 'N',
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMin = 1,
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$DelaySecMax = 300,
+
+        [Parameter()]
+        [switch]$RunLocally,
+
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path $_ -PathType Container })]
+        [string]$OutputPath,
+
+        [Parameter()]
+        [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+        [string]$OutputFormat = 'CSV',
+
+        [Parameter()]
+        [string]$LoadGUID,
+
+        [Parameter()]
+        [ValidateSet('Y', 'N')]
+        [string]$DeployFRK = 'N',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$FRKDatabase = 'master',
+
+        [Parameter()]
+        [ValidateSet('Y', 'N')]
+        [string]$CheckProcedureCache = 'N',
+
+        [Parameter()]
+        [ValidateSet('Y', 'N')]
+        [string]$CheckUserDatabaseObjects = 'Y'
+    )
+
+    # -------------------------------------------------------------------------
+    begin {
+        #region Module Dependency Check
+        $SCRIPT_VERSION  = '4.1.0'
+        $requiredVersion = [Version]'2.0.0'
+        $dbatoolsMod     = Get-Module -Name dbatools -ListAvailable |
+                               Sort-Object Version -Descending |
+                               Select-Object -First 1
+        if (-not $dbatoolsMod) {
+            throw 'dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers'
+        }
+        if ($dbatoolsMod.Version -lt $requiredVersion) {
+            Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended."
+        }
+        Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+        #endregion
+
+        #region Initialization
+        $ErrorActionPreference = 'Stop'
+        $Script:ErrorCount     = 0
+        $Script:WarningCount   = 0
+        $Script:Results        = New-Object 'System.Collections.Generic.List[PSCustomObject]'
+        $elapsedTime           = [System.Diagnostics.Stopwatch]::StartNew()
+        $stepName              = 'Initialization'
+        $collectedAt           = Get-Date
+
+        if ($LoadGUID) { $runGUID = $LoadGUID }
+        else           { $runGUID = [guid]::NewGuid().ToString() }
+
+        # Convert Y/N flags to int for SQL parameters
+        $cpc = if ($CheckProcedureCache      -eq 'Y') { 1 } else { 0 }
+        $cud = if ($CheckUserDatabaseObjects -eq 'Y') { 1 } else { 0 }
+        #endregion
+
+        #region Credential Splats
+        $credParam = @{}
+        if ($SqlCredential) { $credParam['SqlCredential'] = $SqlCredential }
+
+        $cmsCredParam = @{}
+        if ($SqlCredential) { $cmsCredParam['SqlCredential'] = $SqlCredential }
+        #endregion
+
+        #region Write-DbaLog Helper
+        function Write-DbaLog {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory)][string]$Message,
+                [Parameter()][ValidateSet('INFO','WARN','ERROR','DEBUG')][string]$Level = 'INFO'
+            )
+            $ts    = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            $entry = "[$ts] [$Level] $Message"
+            switch ($Level) {
+                'INFO'  { Write-Verbose $entry }
+                'WARN'  { Write-Warning $entry; $Script:WarningCount++ }
+                'ERROR' { Write-Warning "ERROR: $Message"; $Script:ErrorCount++ }
+                'DEBUG' { Write-Debug $entry }
+            }
+        }
+        #endregion
+
+        #region Write-ToCms Helper
+        function Write-ToCms {
+            param (
+                [Parameter(Mandatory)][object]$Data,
+                [Parameter(Mandatory)][string]$Table,
+                [Parameter(Mandatory)][string]$Label
+            )
+            try {
+                $Data | Write-DbaDbTableData `
+                    -SqlInstance $CMSInstanceName `
+                    -Database    $CMSDatabaseName `
+                    -Table       $Table `
+                    -AutoCreateTable `
+                    @cmsCredParam `
+                    -EnableException
+                Write-DbaLog "[$Label] Wrote $(@($Data).Count) row(s) to $Table"
+            }
+            catch {
+                Write-DbaLog "[$Label] CMS write to $Table failed - $($_.Exception.Message)" -Level WARN
+                # Non-fatal: CMS failure must never kill collection
+            }
+        }
+        #endregion
+
+        #region CMS Connection Test
+        function Test-CMSConnection {
+            try {
+                $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @cmsCredParam -ErrorAction Stop
+                return $true
+            }
+            catch { return $false }
+        }
+        #endregion
+
+        Write-DbaLog "Invoke-CentralBlitzCollection v$SCRIPT_VERSION started. LoadGUID: $runGUID"
+        Write-DbaLog "DeployFRK: $DeployFRK | FRKDatabase: $FRKDatabase | CheckProcCache: $CheckProcedureCache"
+
+        #region Stagger Delay
+        if ($IntroduceDelay -eq 'Y') {
+            $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+            Write-DbaLog "Stagger delay: sleeping $delay seconds."
+            Start-Sleep -Seconds $delay
+        }
+        #endregion
+
+        #region Instance Discovery
+        $stepName = 'Instance Discovery'
+        if ($RunLocally) {
+            if (-not $CMSInstanceName) {
+                throw '-CMSInstanceName is required when -RunLocally is specified.'
+            }
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+            $localHost  = $env:COMPUTERNAME
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance    $CMSInstanceName `
+                -Database       $CMSDatabaseName `
+                -Query          'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct, @RunLocally = 1, @LocalServerName = @sn' `
+                -SqlParameters  @{ ct = 'Baseline'; sn = $localHost } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam   -EnableException
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName; $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv }
+            })
+            Write-DbaLog "RunLocally resolved $($SqlInstance.Count) instance(s) for $localHost."
+        }
+        elseif ($CMSInstanceName -and (-not $SqlInstance)) {
+            if (-not (Test-CMSConnection)) {
+                throw "CMS instance '$CMSInstanceName' is not reachable."
+            }
+            $targetRows = Invoke-DbaQuery `
+                -SqlInstance    $CMSInstanceName `
+                -Database       $CMSDatabaseName `
+                -Query          'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct' `
+                -SqlParameters  @{ ct = 'Baseline' } `
+                -CommandTimeout $CommandTimeout `
+                @cmsCredParam   -EnableException
+            $SqlInstance = @($targetRows | ForEach-Object {
+                $sv = $_.ServerName; $in = $_.InstanceName
+                if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv }
+            })
+            Write-DbaLog "CMS discovery resolved $($SqlInstance.Count) instance(s)."
+        }
+
+        if (-not $SqlInstance -or $SqlInstance.Count -eq 0) {
+            throw 'No target instances resolved. Provide -SqlInstance or configure -CMSInstanceName.'
+        }
+        #endregion
+    }
+
+    # -------------------------------------------------------------------------
+    process {
+        $instanceErrors = New-Object 'System.Collections.Generic.List[string]'
+
+        foreach ($instance in $SqlInstance) {
+
+            $hostName     = ($instance -split '[\\,]')[0]
+            $instancePart = if ($instance -match '\\') { ($instance -split '\\')[1] } else { 'MSSQLSERVER' }
+
+            Write-DbaLog "=== Begin Blitz collection: $instance ==="
+
+            try {
+                # =============================================================
+                #region Phase 1: Deploy FRK (optional)
+                # =============================================================
+                if ($DeployFRK -eq 'Y') {
+                    $stepName = "Deploy FRK on $instance"
+                    if ($PSCmdlet.ShouldProcess($instance, 'Install/update sp_Blitz via Install-DbaFirstResponderKit')) {
+                        Write-DbaLog "[Deploy] Installing/updating First Responder Kit on $instance.$FRKDatabase"
+                        try {
+                            Install-DbaFirstResponderKit `
+                                -SqlInstance $instance `
+                                -Database    $FRKDatabase `
+                                @credParam   -EnableException | Out-Null
+                            Write-DbaLog "[Deploy] First Responder Kit installed/updated on $instance.$FRKDatabase"
+                        }
+                        catch {
+                            Write-DbaLog "[Deploy] Failed to install FRK on $($instance) - $($_.Exception.Message)" -Level WARN
+                            # Non-fatal: if sp_Blitz already exists we can still run it
+                        }
+                    }
+                }
+                #endregion
+
+                # =============================================================
+                #region Phase 2: Verify sp_Blitz exists
+                # =============================================================
+                $stepName  = "Verify sp_Blitz on $instance"
+                $spExists  = Invoke-DbaQuery `
+                    -SqlInstance    $instance `
+                    -Database       $FRKDatabase `
+                    -Query          "SELECT COUNT(1) AS Cnt FROM sys.objects WHERE name = 'sp_Blitz' AND type = 'P'" `
+                    -CommandTimeout $CommandTimeout `
+                    @credParam      -EnableException
+
+                if ($spExists.Cnt -eq 0) {
+                    Write-DbaLog "[Blitz] sp_Blitz not found on $instance.$FRKDatabase. Set -DeployFRK Y to install it." -Level WARN
+                    $Script:Results.Add([PSCustomObject]@{
+                        PSTypeName    = 'CentralDB.BlitzResult'
+                        SqlInstance   = $instance
+                        FindingCount  = 0
+                        LoadGUID      = $runGUID
+                        CollectedAt   = $collectedAt
+                        Status        = 'Skipped'
+                        ErrorMessage  = "sp_Blitz not found on $FRKDatabase"
+                    })
+                    continue
+                }
+                #endregion
+
+                # =============================================================
+                #region Phase 3: Execute sp_Blitz and capture results
+                # =============================================================
+                $stepName = "Execute sp_Blitz on $instance"
+                Write-DbaLog "[Blitz] Executing sp_Blitz on $instance (CheckProcCache=$CheckProcedureCache, CheckUserDB=$CheckUserDatabaseObjects)"
+
+                $blitzQuery = 'EXEC dbo.sp_Blitz' +
+                              ' @CheckServerInfo = 1' +
+                              ',@CheckUserDatabaseObjects = @cud' +
+                              ',@CheckProcedureCache = @cpc' +
+                              ',@OutputProcedureCache = @cpc'
+
+                $blitzRows = Invoke-DbaQuery `
+                    -SqlInstance    $instance `
+                    -Database       $FRKDatabase `
+                    -Query          $blitzQuery `
+                    -SqlParameters  @{ cud = $cud; cpc = $cpc } `
+                    -CommandTimeout $CommandTimeout `
+                    @credParam      -EnableException
+
+                if (-not $blitzRows) {
+                    Write-DbaLog "[Blitz] sp_Blitz returned no rows on $instance." -Level WARN
+                    $Script:Results.Add([PSCustomObject]@{
+                        PSTypeName    = 'CentralDB.BlitzResult'
+                        SqlInstance   = $instance
+                        FindingCount  = 0
+                        LoadGUID      = $runGUID
+                        CollectedAt   = $collectedAt
+                        Status        = 'Success'
+                        ErrorMessage  = $null
+                    })
+                    continue
+                }
+
+                Write-DbaLog "[Blitz] sp_Blitz returned $(@($blitzRows).Count) finding(s) from $instance"
+                #endregion
+
+                # =============================================================
+                #region Phase 4: Enrich and centralize
+                # =============================================================
+                $stepName = "Centralizing Blitz results from $instance"
+
+                $enriched = $blitzRows | Select-Object `
+                    @{ n = 'CollectionServerName'; e = { $hostName } },
+                    @{ n = 'CollectionInstance';   e = { $instance } },
+                    @{ n = 'LoadGUID';             e = { $runGUID } },
+                    @{ n = 'CollectedAt';          e = { $collectedAt } },
+                    *
+
+                if ($PSCmdlet.ShouldProcess($instance, 'Write Blitz findings to CentralDB')) {
+                    Write-ToCms -Data $enriched -Table '[FRK].[Blitz]' -Label 'Blitz'
+                }
+                #endregion
+
+                # Update CMS collection timestamp
+                if ($PSCmdlet.ShouldProcess($instance, 'Update Blitz collection timestamp in CentralDB')) {
+                    try {
+                        Invoke-DbaQuery `
+                            -SqlInstance    $CMSInstanceName `
+                            -Database       $CMSDatabaseName `
+                            -Query          'EXEC [Svr].[usp_SetCollectionLastRun] @CollectionType = @ct, @ServerName = @sv, @InstanceName = @in, @LoadGUID = @lg' `
+                            -SqlParameters  @{ ct = 'Baseline'; sv = $hostName; in = $instancePart; lg = $runGUID } `
+                            -CommandTimeout $CommandTimeout `
+                            @cmsCredParam   -EnableException
+                    }
+                    catch {
+                        Write-DbaLog "Failed to update collection timestamp for $($instance) - $($_.Exception.Message)" -Level WARN
+                    }
+                }
+
+                Write-DbaLog "=== Completed $instance - $(@($blitzRows).Count) finding(s) ==="
+
+                $Script:Results.Add([PSCustomObject]@{
+                    PSTypeName    = 'CentralDB.BlitzResult'
+                    SqlInstance   = $instance
+                    FindingCount  = @($blitzRows).Count
+                    LoadGUID      = $runGUID
+                    CollectedAt   = $collectedAt
+                    Status        = 'Success'
+                    ErrorMessage  = $null
+                })
+            }
+            catch {
+                $msg = "[$($stepName)] Failed on $($instance) - $($_.Exception.Message)"
+                $instanceErrors.Add($msg)
+                Write-DbaLog $msg -Level ERROR
+
+                $Script:Results.Add([PSCustomObject]@{
+                    PSTypeName    = 'CentralDB.BlitzResult'
+                    SqlInstance   = $instance
+                    FindingCount  = 0
+                    LoadGUID      = $runGUID
+                    CollectedAt   = $collectedAt
+                    Status        = 'Failed'
+                    ErrorMessage  = $_.Exception.Message
+                })
+
+                continue
+            }
+        }
+
+        if ($instanceErrors.Count -gt 0) {
+            $summary = $instanceErrors -join "`n"
+            throw "Invoke-CentralBlitzCollection completed with $($instanceErrors.Count) instance error(s):`n$summary"
+        }
+    }
+
+    # -------------------------------------------------------------------------
+    end {
+        $elapsedTime.Stop()
+        $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+
+        if ($Script:ErrorCount -gt 0) {
+            Write-Warning "Invoke-CentralBlitzCollection completed with $Script:ErrorCount error(s) in $duration."
+        }
+        else {
+            Write-DbaLog "Invoke-CentralBlitzCollection completed successfully in $duration."
+        }
+
+        #region Export Output
+        $exportBase = Join-Path $OutputPath ("BlitzCollection_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss')")
+
+        switch ($OutputFormat) {
+            'CSV'      { $Script:Results | Export-Csv -Path "$exportBase.csv"  -NoTypeInformation }
+            'JSON'     { $Script:Results | ConvertTo-Json -Depth 5 | Out-File -FilePath "$exportBase.json" -Encoding utf8 }
+            'HTML'     { $Script:Results | ConvertTo-Html -Title 'CentralDB Blitz Collection' | Out-File -FilePath "$exportBase.html" -Encoding utf8 }
+            'GridView' { $Script:Results | Out-GridView -Title 'CentralDB Blitz Collection' }
+            'Excel'    {
+                if (Get-Module -Name ImportExcel -ListAvailable) {
+                    $Script:Results | Export-Excel -Path "$exportBase.xlsx" -AutoSize -FreezeTopRow
+                }
+                else {
+                    Write-DbaLog 'ImportExcel not found - falling back to CSV.' -Level WARN
+                    $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation
+                }
+            }
+        }
+
+        Write-DbaLog "Output written to $exportBase.$($OutputFormat.ToLower())"
+        #endregion
+
+        $Script:Results
+    }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION: forwards script params to the function
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') {
+        $invokeParams[$key] = $PSBoundParameters[$key]
+    }
+}
+Invoke-CentralBlitzCollection @invokeParams -Confirm:$false

--- a/Collect/Invoke-CentralIndexOptimize.ps1
+++ b/Collect/Invoke-CentralIndexOptimize.ps1
@@ -1,0 +1,438 @@
+# ============================================================================
+# PART 1 - Script-level parameter block
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+param (
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+    [Parameter()][PSCredential]$SqlCredential,
+    [Parameter()][string]$CMSInstanceName,
+    [Parameter()][ValidateNotNullOrEmpty()][string]$CMSDatabaseName = 'CentralDB',
+    [Parameter()][ValidateRange(60, 86400)][int]$CommandTimeout = 14400,
+    [Parameter()][ValidateSet('Y', 'N')][string]$IntroduceDelay = 'N',
+    [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMin = 1,
+    [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMax = 300,
+    [Parameter()][switch]$RunLocally,
+    [Parameter(Mandatory)][ValidateScript({ Test-Path $_ -PathType Container })][string]$OutputPath,
+    [Parameter()][ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')][string]$OutputFormat = 'CSV',
+    [Parameter()][string]$LoadGUID,
+    [Parameter()][ValidateSet('Y', 'N')][string]$DeployOla = 'N',
+    [Parameter()][ValidateNotNullOrEmpty()][string]$OlaDatabase = 'master',
+    [Parameter()][string]$Databases = 'USER_DATABASES',
+    [Parameter()][string]$FragmentationLow = $null,
+    [Parameter()][string]$FragmentationMedium = 'INDEX_REORGANIZE,INDEX_REBUILD_ONLINE,INDEX_REBUILD_OFFLINE',
+    [Parameter()][string]$FragmentationHigh = 'INDEX_REBUILD_ONLINE,INDEX_REBUILD_OFFLINE',
+    [Parameter()][int]$FragmentationLevel1 = 5,
+    [Parameter()][int]$FragmentationLevel2 = 30,
+    [Parameter()][int]$PageCountLevel,
+    [Parameter()][ValidateSet('Y', 'N')][string]$SortInTempdb = 'Y',
+    [Parameter()][int]$MaxDOP,
+    [Parameter()][ValidateSet('Y', 'N')][string]$LOBCompaction = 'Y',
+    [Parameter()][ValidateSet('ALL', 'COLUMNS', 'INDEX')][string]$UpdateStatistics,
+    [Parameter()][ValidateSet('Y', 'N')][string]$OnlyModifiedStatistics = 'N',
+    [Parameter()][string]$Indexes,
+    [Parameter()][int]$TimeLimit,
+    [Parameter()][string]$AvailabilityGroups,
+    [Parameter()][ValidateSet('ALL', 'PRIMARY', 'SECONDARY', 'PREFERRED_BACKUP_REPLICA')][string]$Updateability = 'ALL'
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Invoke-CentralIndexOptimize {
+<#
+.SYNOPSIS
+    Executes Ola Hallengren IndexOptimize against one or more SQL Server
+    instances and centralizes the CommandLog results into CentralDB.
+
+.DESCRIPTION
+    Replaces the legacy Get-OlaHallengren-Index.ps1 (raw SqlClient, 2017).
+
+    Two phases per instance:
+
+    Deploy (optional, -DeployOla Y):
+      Calls Install-DbaMaintenanceSolution to install/update Ola's solution.
+
+    Execute and Collect:
+      Calls IndexOptimize via Invoke-DbaQuery with @LogToTable = 'Y'.
+      Queries CommandLog filtered by LoadGUID, centralizes to CentralDB,
+      then cleans up local CommandLog rows.
+
+    CentralDB write failures are non-fatal (WARN only).
+
+.PARAMETER SqlInstance
+    Target SQL Server instances. Accepts pipeline input.
+
+.PARAMETER SqlCredential
+    PSCredential for SQL Server authentication.
+
+.PARAMETER CMSInstanceName
+    CentralDB instance for target discovery and result storage.
+
+.PARAMETER CMSDatabaseName
+    CentralDB database name. Default: CentralDB.
+
+.PARAMETER CommandTimeout
+    Query timeout in seconds. Default: 14400 (4 hours).
+
+.PARAMETER IntroduceDelay
+    Set to 'Y' to sleep a random interval before processing.
+
+.PARAMETER DelaySecMin
+    Minimum stagger delay in seconds. Default: 1.
+
+.PARAMETER DelaySecMax
+    Maximum stagger delay in seconds. Default: 300.
+
+.PARAMETER RunLocally
+    Restricts CMS discovery to the local machine only.
+
+.PARAMETER OutputPath
+    Directory for exported output files. Must already exist.
+
+.PARAMETER OutputFormat
+    Output format. Default: CSV.
+
+.PARAMETER LoadGUID
+    Correlation GUID. Generated automatically when omitted.
+
+.PARAMETER DeployOla
+    Set to 'Y' to install/update Ola's solution before running. Default: 'N'.
+
+.PARAMETER OlaDatabase
+    Database where Ola's solution is installed. Default: master.
+
+.PARAMETER Databases
+    Ola @Databases parameter. Default: USER_DATABASES.
+
+.PARAMETER FragmentationLow
+    Action for indexes with fragmentation below FragmentationLevel1.
+
+.PARAMETER FragmentationMedium
+    Action for indexes between levels 1 and 2.
+    Default: INDEX_REORGANIZE,INDEX_REBUILD_ONLINE,INDEX_REBUILD_OFFLINE.
+
+.PARAMETER FragmentationHigh
+    Action for indexes above FragmentationLevel2.
+    Default: INDEX_REBUILD_ONLINE,INDEX_REBUILD_OFFLINE.
+
+.PARAMETER FragmentationLevel1
+    Lower fragmentation threshold %. Default: 5.
+
+.PARAMETER FragmentationLevel2
+    Upper fragmentation threshold %. Default: 30.
+
+.PARAMETER PageCountLevel
+    Minimum page count for an index to be considered. Default: Ola default.
+
+.PARAMETER SortInTempdb
+    Sort intermediate results in tempdb. Y or N. Default: Y.
+
+.PARAMETER MaxDOP
+    Max degree of parallelism for the operation.
+
+.PARAMETER LOBCompaction
+    Compact LOB pages during REORGANIZE. Y or N. Default: Y.
+
+.PARAMETER UpdateStatistics
+    Update statistics. ALL, COLUMNS, or INDEX.
+
+.PARAMETER OnlyModifiedStatistics
+    Only update statistics that have been modified. Y or N. Default: N.
+
+.PARAMETER Indexes
+    Comma-separated list of specific indexes to process.
+
+.PARAMETER TimeLimit
+    Maximum runtime in seconds.
+
+.PARAMETER AvailabilityGroups
+    Ola @AvailabilityGroups filter.
+
+.PARAMETER Updateability
+    Which AG replicas to process. Default: ALL.
+
+.EXAMPLE
+    .\Invoke-CentralIndexOptimize.ps1 -SqlInstance 'SQL-01' -CMSInstanceName 'CMS-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run. No index operations are performed.
+
+.EXAMPLE
+    .\Invoke-CentralIndexOptimize.ps1 -CMSInstanceName 'CMS-01' -RunLocally -OutputPath 'D:\Logs'
+    MSX/TSX mode: index optimize on local machine user databases.
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : 2024-01-01
+    Version     : 4.1.0
+    Replaces    : CentralDB/Get-OlaHallengren-Index.ps1
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+                  Ola Hallengren maintenance solution (or -DeployOla Y)
+    Impact      : HIGH - rebuilds/reorganizes indexes
+    Schedule    : Weekly via SQL Agent
+
+    Permissions :
+        Target    : db_owner on user databases
+        CentralDB : EXECUTE on [Svr].[usp_GetCollectionTargets]
+                    EXECUTE on [Svr].[usp_SetCollectionLastRun]
+                    INSERT on [Inst].[CommandLog]
+
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\share\CentralDB\Collect\Invoke-CentralIndexOptimize.ps1"
+                        -CMSInstanceName "$(ESCAPE_DQUOTE(SRVR))"
+                        -RunLocally
+                        -OutputPath "D:\Logs\CentralDB"
+
+    Attribution:
+        IndexOptimize is created and maintained by Ola Hallengren.
+        https://ola.hallengren.com
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [string[]]$SqlInstance,
+        [Parameter()][PSCredential]$SqlCredential,
+        [Parameter()][string]$CMSInstanceName,
+        [Parameter()][ValidateNotNullOrEmpty()][string]$CMSDatabaseName = 'CentralDB',
+        [Parameter()][ValidateRange(60, 86400)][int]$CommandTimeout = 14400,
+        [Parameter()][ValidateSet('Y', 'N')][string]$IntroduceDelay = 'N',
+        [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMin = 1,
+        [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMax = 300,
+        [Parameter()][switch]$RunLocally,
+        [Parameter(Mandatory)][ValidateScript({ Test-Path $_ -PathType Container })][string]$OutputPath,
+        [Parameter()][ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')][string]$OutputFormat = 'CSV',
+        [Parameter()][string]$LoadGUID,
+        [Parameter()][ValidateSet('Y', 'N')][string]$DeployOla = 'N',
+        [Parameter()][ValidateNotNullOrEmpty()][string]$OlaDatabase = 'master',
+        [Parameter()][string]$Databases = 'USER_DATABASES',
+        [Parameter()][string]$FragmentationLow = $null,
+        [Parameter()][string]$FragmentationMedium = 'INDEX_REORGANIZE,INDEX_REBUILD_ONLINE,INDEX_REBUILD_OFFLINE',
+        [Parameter()][string]$FragmentationHigh = 'INDEX_REBUILD_ONLINE,INDEX_REBUILD_OFFLINE',
+        [Parameter()][int]$FragmentationLevel1 = 5,
+        [Parameter()][int]$FragmentationLevel2 = 30,
+        [Parameter()][int]$PageCountLevel,
+        [Parameter()][ValidateSet('Y', 'N')][string]$SortInTempdb = 'Y',
+        [Parameter()][int]$MaxDOP,
+        [Parameter()][ValidateSet('Y', 'N')][string]$LOBCompaction = 'Y',
+        [Parameter()][ValidateSet('ALL', 'COLUMNS', 'INDEX')][string]$UpdateStatistics,
+        [Parameter()][ValidateSet('Y', 'N')][string]$OnlyModifiedStatistics = 'N',
+        [Parameter()][string]$Indexes,
+        [Parameter()][int]$TimeLimit,
+        [Parameter()][string]$AvailabilityGroups,
+        [Parameter()][ValidateSet('ALL', 'PRIMARY', 'SECONDARY', 'PREFERRED_BACKUP_REPLICA')][string]$Updateability = 'ALL'
+    )
+
+    begin {
+        #region Module Check
+        $SCRIPT_VERSION  = '4.1.0'
+        $requiredVersion = [Version]'2.0.0'
+        $dbatoolsMod     = Get-Module -Name dbatools -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+        if (-not $dbatoolsMod)                        { throw 'dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers' }
+        if ($dbatoolsMod.Version -lt $requiredVersion){ Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended." }
+        Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+        #endregion
+
+        #region Init
+        $ErrorActionPreference = 'Stop'
+        $Script:ErrorCount     = 0
+        $Script:WarningCount   = 0
+        $Script:Results        = New-Object 'System.Collections.Generic.List[PSCustomObject]'
+        $elapsedTime           = [System.Diagnostics.Stopwatch]::StartNew()
+        $stepName              = 'Initialization'
+        $collectedAt           = Get-Date
+        if ($LoadGUID) { $runGUID = $LoadGUID } else { $runGUID = [guid]::NewGuid().ToString() }
+        $credParam    = @{}; if ($SqlCredential) { $credParam['SqlCredential']    = $SqlCredential }
+        $cmsCredParam = @{}; if ($SqlCredential) { $cmsCredParam['SqlCredential'] = $SqlCredential }
+        #endregion
+
+        #region Helpers
+        function Write-DbaLog {
+            param([Parameter(Mandatory)][string]$Message, [ValidateSet('INFO','WARN','ERROR','DEBUG')][string]$Level = 'INFO')
+            $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            switch ($Level) {
+                'INFO'  { Write-Verbose  "[$ts] [INFO]  $Message" }
+                'WARN'  { Write-Warning  "[$ts] [WARN]  $Message"; $Script:WarningCount++ }
+                'ERROR' { Write-Warning  "[$ts] [ERROR] $Message"; $Script:ErrorCount++ }
+                'DEBUG' { Write-Debug    "[$ts] [DEBUG] $Message" }
+            }
+        }
+        function Write-ToCms {
+            param([Parameter(Mandatory)][object]$Data, [Parameter(Mandatory)][string]$Table, [Parameter(Mandatory)][string]$Label)
+            try {
+                $Data | Write-DbaDbTableData -SqlInstance $CMSInstanceName -Database $CMSDatabaseName -Table $Table -AutoCreateTable @cmsCredParam -EnableException
+                Write-DbaLog "[$Label] Wrote $(@($Data).Count) row(s) to $Table"
+            }
+            catch { Write-DbaLog "[$Label] CMS write to $Table failed - $($_.Exception.Message)" -Level WARN } # Non-fatal
+        }
+        function Test-CMSConnection {
+            try { $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @cmsCredParam -ErrorAction Stop; return $true }
+            catch { return $false }
+        }
+        #endregion
+
+        Write-DbaLog "Invoke-CentralIndexOptimize v$SCRIPT_VERSION started. LoadGUID: $runGUID"
+
+        if ($IntroduceDelay -eq 'Y') {
+            $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+            Write-DbaLog "Stagger delay: $delay seconds."; Start-Sleep -Seconds $delay
+        }
+
+        #region Instance Discovery
+        $stepName = 'Instance Discovery'
+        if ($RunLocally) {
+            if (-not $CMSInstanceName) { throw '-CMSInstanceName is required when -RunLocally is specified.' }
+            if (-not (Test-CMSConnection)) { throw "CMS instance '$CMSInstanceName' is not reachable." }
+            $localHost = $env:COMPUTERNAME
+            $rows = Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                -Query 'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct, @RunLocally = 1, @LocalServerName = @sn' `
+                -SqlParameters @{ ct = 'Baseline'; sn = $localHost } -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+            $SqlInstance = @($rows | ForEach-Object { $sv=$_.ServerName; $in=$_.InstanceName; if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv } })
+        }
+        elseif ($CMSInstanceName -and (-not $SqlInstance)) {
+            if (-not (Test-CMSConnection)) { throw "CMS instance '$CMSInstanceName' is not reachable." }
+            $rows = Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                -Query 'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct' `
+                -SqlParameters @{ ct = 'Baseline' } -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+            $SqlInstance = @($rows | ForEach-Object { $sv=$_.ServerName; $in=$_.InstanceName; if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv } })
+        }
+        if (-not $SqlInstance -or $SqlInstance.Count -eq 0) { throw 'No target instances resolved.' }
+        #endregion
+    }
+
+    process {
+        $instanceErrors = New-Object 'System.Collections.Generic.List[string]'
+
+        foreach ($instance in $SqlInstance) {
+            $hostName     = ($instance -split '[\\,]')[0]
+            $instancePart = if ($instance -match '\\') { ($instance -split '\\')[1] } else { 'MSSQLSERVER' }
+            Write-DbaLog "=== Begin index optimize: $instance ==="
+
+            try {
+                # Phase 1: Optional deploy
+                if ($DeployOla -eq 'Y') {
+                    $stepName = "Deploy Ola on $instance"
+                    if ($PSCmdlet.ShouldProcess($instance, 'Install/update Ola Hallengren maintenance solution')) {
+                        try {
+                            Install-DbaMaintenanceSolution -SqlInstance $instance -Database $OlaDatabase @credParam -EnableException | Out-Null
+                            Write-DbaLog "[Deploy] Ola installed/updated on $instance.$OlaDatabase"
+                        }
+                        catch { Write-DbaLog "[Deploy] Failed on $($instance) - $($_.Exception.Message)" -Level WARN }
+                    }
+                }
+
+                # Phase 2: Verify IndexOptimize exists
+                $stepName  = "Verify IndexOptimize on $instance"
+                $procCheck = Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                    -Query "SELECT COUNT(1) AS Cnt FROM sys.objects WHERE name = 'IndexOptimize' AND type = 'P'" `
+                    -CommandTimeout 60 @credParam -EnableException
+                if ($procCheck.Cnt -eq 0) {
+                    Write-DbaLog "[Index] IndexOptimize not found on $instance.$OlaDatabase. Use -DeployOla Y." -Level WARN
+                    $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.IndexResult'; SqlInstance=$instance; RowsCollected=0; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Skipped'; ErrorMessage="IndexOptimize not found on $OlaDatabase" })
+                    continue
+                }
+
+                # Phase 3: Build and execute IndexOptimize
+                $stepName = "Execute IndexOptimize on $instance"
+                if ($PSCmdlet.ShouldProcess($instance, "Execute IndexOptimize ($Databases)")) {
+
+                    $olaParams  = "@Databases = '$Databases', @LogToTable = 'Y', @Execute = 'Y'"
+                    $olaParams += ", @LoadGUID = '$runGUID'"
+                    $olaParams += ", @FragmentationLevel1 = $FragmentationLevel1"
+                    $olaParams += ", @FragmentationLevel2 = $FragmentationLevel2"
+                    $olaParams += ", @SortInTempdb = '$SortInTempdb'"
+                    $olaParams += ", @LOBCompaction = '$LOBCompaction'"
+                    $olaParams += ", @OnlyModifiedStatistics = '$OnlyModifiedStatistics'"
+                    $olaParams += ", @Updateability = '$Updateability'"
+                    if ($FragmentationLow)    { $olaParams += ", @FragmentationLow = '$FragmentationLow'" }
+                    if ($FragmentationMedium) { $olaParams += ", @FragmentationMedium = '$FragmentationMedium'" }
+                    if ($FragmentationHigh)   { $olaParams += ", @FragmentationHigh = '$FragmentationHigh'" }
+                    if ($PageCountLevel)      { $olaParams += ", @PageCountLevel = $PageCountLevel" }
+                    if ($MaxDOP)              { $olaParams += ", @MaxDOP = $MaxDOP" }
+                    if ($UpdateStatistics)    { $olaParams += ", @UpdateStatistics = '$UpdateStatistics'" }
+                    if ($Indexes)             { $olaParams += ", @Indexes = '$Indexes'" }
+                    if ($TimeLimit)           { $olaParams += ", @TimeLimit = $TimeLimit" }
+                    if ($AvailabilityGroups)  { $olaParams += ", @AvailabilityGroups = '$AvailabilityGroups'" }
+
+                    Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                        -Query "EXEC dbo.IndexOptimize $olaParams" `
+                        -CommandTimeout $CommandTimeout @credParam -EnableException | Out-Null
+                    Write-DbaLog "[Index] IndexOptimize completed on $instance"
+
+                    # Collect and centralize
+                    $logRows = Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                        -Query 'SELECT * FROM dbo.CommandLog WHERE LoadGUID = @lg' `
+                        -SqlParameters @{ lg = $runGUID } -CommandTimeout 60 @credParam -EnableException
+                    if ($logRows) {
+                        $enriched = $logRows | Select-Object @{ n='CollectionServerName'; e={ $hostName } }, @{ n='CollectionInstance'; e={ $instance } }, @{ n='LoadGUID'; e={ $runGUID } }, @{ n='CollectedAt'; e={ $collectedAt } }, *
+                        Write-ToCms -Data $enriched -Table '[Inst].[CommandLog]' -Label 'Index'
+                    }
+
+                    # Cleanup
+                    try {
+                        Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                            -Query 'DELETE FROM dbo.CommandLog WHERE LoadGUID = @lg' `
+                            -SqlParameters @{ lg = $runGUID } -CommandTimeout 60 @credParam -EnableException | Out-Null
+                        Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                            -Query 'DELETE FROM dbo.CommandLog WHERE EndTime <= DATEADD(DAY, -1, GETDATE())' `
+                            -CommandTimeout 60 @credParam -EnableException | Out-Null
+                    }
+                    catch { Write-DbaLog "[Index] CommandLog cleanup failed on $($instance) - $($_.Exception.Message)" -Level WARN }
+
+                    $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.IndexResult'; SqlInstance=$instance; RowsCollected=@($logRows).Count; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Success'; ErrorMessage=$null })
+                }
+
+                try {
+                    Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                        -Query 'EXEC [Svr].[usp_SetCollectionLastRun] @CollectionType = @ct, @ServerName = @sv, @InstanceName = @in, @LoadGUID = @lg' `
+                        -SqlParameters @{ ct='Baseline'; sv=$hostName; in=$instancePart; lg=$runGUID } `
+                        -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+                }
+                catch { Write-DbaLog "Failed to update collection timestamp for $($instance) - $($_.Exception.Message)" -Level WARN }
+
+                Write-DbaLog "=== Completed $instance ==="
+            }
+            catch {
+                $msg = "[$($stepName)] Failed on $($instance) - $($_.Exception.Message)"
+                $instanceErrors.Add($msg)
+                Write-DbaLog $msg -Level ERROR
+                $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.IndexResult'; SqlInstance=$instance; RowsCollected=0; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Failed'; ErrorMessage=$_.Exception.Message })
+                continue
+            }
+        }
+
+        if ($instanceErrors.Count -gt 0) {
+            throw "Invoke-CentralIndexOptimize completed with $($instanceErrors.Count) instance error(s):`n$($instanceErrors -join "`n")"
+        }
+    }
+
+    end {
+        $elapsedTime.Stop()
+        $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+        if ($Script:ErrorCount -gt 0) { Write-Warning "Invoke-CentralIndexOptimize completed with $Script:ErrorCount error(s) in $duration." }
+        else { Write-DbaLog "Invoke-CentralIndexOptimize completed successfully in $duration." }
+        $exportBase = Join-Path $OutputPath ("IndexOptimize_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss')")
+        switch ($OutputFormat) {
+            'CSV'      { $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation }
+            'JSON'     { $Script:Results | ConvertTo-Json -Depth 5 | Out-File -FilePath "$exportBase.json" -Encoding utf8 }
+            'HTML'     { $Script:Results | ConvertTo-Html -Title 'CentralDB Index Optimize' | Out-File -FilePath "$exportBase.html" -Encoding utf8 }
+            'GridView' { $Script:Results | Out-GridView -Title 'CentralDB Index Optimize' }
+            'Excel'    {
+                if (Get-Module -Name ImportExcel -ListAvailable) { $Script:Results | Export-Excel -Path "$exportBase.xlsx" -AutoSize -FreezeTopRow }
+                else { Write-DbaLog 'ImportExcel not found - falling back to CSV.' -Level WARN; $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation }
+            }
+        }
+        Write-DbaLog "Output written to $exportBase.$($OutputFormat.ToLower())"
+        $Script:Results
+    }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') { $invokeParams[$key] = $PSBoundParameters[$key] }
+}
+Invoke-CentralIndexOptimize @invokeParams -Confirm:$false

--- a/Collect/Invoke-CentralIntegrityCheck.ps1
+++ b/Collect/Invoke-CentralIntegrityCheck.ps1
@@ -1,0 +1,418 @@
+# ============================================================================
+# PART 1 - Script-level parameter block
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+param (
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+    [Parameter()][PSCredential]$SqlCredential,
+    [Parameter()][string]$CMSInstanceName,
+    [Parameter()][ValidateNotNullOrEmpty()][string]$CMSDatabaseName = 'CentralDB',
+    [Parameter()][ValidateRange(60, 86400)][int]$CommandTimeout = 14400,
+    [Parameter()][ValidateSet('Y', 'N')][string]$IntroduceDelay = 'N',
+    [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMin = 1,
+    [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMax = 300,
+    [Parameter()][switch]$RunLocally,
+    [Parameter(Mandatory)][ValidateScript({ Test-Path $_ -PathType Container })][string]$OutputPath,
+    [Parameter()][ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')][string]$OutputFormat = 'CSV',
+    [Parameter()][string]$LoadGUID,
+    [Parameter()][ValidateSet('Y', 'N')][string]$DeployOla = 'N',
+    [Parameter()][ValidateNotNullOrEmpty()][string]$OlaDatabase = 'master',
+    [Parameter()][string]$Databases = 'ALL_DATABASES',
+    [Parameter()][ValidateSet('CHECKDB', 'CHECKFILEGROUP', 'CHECKTABLE', 'CHECKALLOC', 'CHECKCATALOG')][string]$CheckCommands = 'CHECKDB',
+    [Parameter()][ValidateSet('Y', 'N')][string]$PhysicalOnly = 'Y',
+    [Parameter()][ValidateSet('Y', 'N')][string]$NoIndex = 'N',
+    [Parameter()][ValidateSet('Y', 'N')][string]$ExtendedLogicalChecks = 'N',
+    [Parameter()][ValidateSet('Y', 'N')][string]$TabLock = 'N',
+    [Parameter()][int]$MaxDOP,
+    [Parameter()][string]$AvailabilityGroups,
+    [Parameter()][ValidateSet('ALL', 'PRIMARY', 'SECONDARY', 'PREFERRED_BACKUP_REPLICA')][string]$AvailabilityGroupReplicas = 'ALL',
+    [Parameter()][ValidateSet('ALL', 'READ_WRITE', 'READ_ONLY')][string]$Updateability = 'ALL',
+    [Parameter()][int]$TimeLimit,
+    [Parameter()][int]$LockTimeout = 10800,
+    [Parameter()][ValidateSet('Y', 'N')][string]$DatabasesInParallel = 'N'
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Invoke-CentralIntegrityCheck {
+<#
+.SYNOPSIS
+    Executes Ola Hallengren DatabaseIntegrityCheck against one or more SQL
+    Server instances and centralizes the CommandLog results into CentralDB.
+
+.DESCRIPTION
+    Replaces the legacy Get-OlaHallengren-Integrity.ps1 (raw SqlClient, 2017).
+
+    Two phases per instance:
+
+    Deploy (optional, -DeployOla Y):
+      Calls Install-DbaMaintenanceSolution to install/update Ola's solution.
+
+    Execute and Collect:
+      Calls DatabaseIntegrityCheck via Invoke-DbaQuery with @LogToTable = 'Y'.
+      Queries CommandLog filtered by LoadGUID, centralizes to CentralDB,
+      then cleans up local CommandLog rows.
+
+    CentralDB write failures are non-fatal (WARN only).
+
+.PARAMETER SqlInstance
+    Target SQL Server instances. Accepts pipeline input.
+
+.PARAMETER SqlCredential
+    PSCredential for SQL Server authentication.
+
+.PARAMETER CMSInstanceName
+    CentralDB instance for target discovery and result storage.
+
+.PARAMETER CMSDatabaseName
+    CentralDB database name. Default: CentralDB.
+
+.PARAMETER CommandTimeout
+    Query timeout in seconds. Default: 14400 (4 hours).
+
+.PARAMETER IntroduceDelay
+    Set to 'Y' to sleep a random interval before processing.
+
+.PARAMETER DelaySecMin
+    Minimum stagger delay in seconds. Default: 1.
+
+.PARAMETER DelaySecMax
+    Maximum stagger delay in seconds. Default: 300.
+
+.PARAMETER RunLocally
+    Restricts CMS discovery to the local machine only.
+
+.PARAMETER OutputPath
+    Directory for exported output files. Must already exist.
+
+.PARAMETER OutputFormat
+    Output format. Default: CSV.
+
+.PARAMETER LoadGUID
+    Correlation GUID. Generated automatically when omitted.
+
+.PARAMETER DeployOla
+    Set to 'Y' to install/update Ola's solution before running. Default: 'N'.
+
+.PARAMETER OlaDatabase
+    Database where Ola's solution is installed. Default: master.
+
+.PARAMETER Databases
+    Ola @Databases parameter. Default: ALL_DATABASES.
+
+.PARAMETER CheckCommands
+    DBCC command to run. Default: CHECKDB.
+    Options: CHECKDB, CHECKFILEGROUP, CHECKTABLE, CHECKALLOC, CHECKCATALOG.
+
+.PARAMETER PhysicalOnly
+    Limit check to physical structure. Y or N. Default: Y.
+
+.PARAMETER NoIndex
+    Skip non-clustered index checks. Y or N. Default: N.
+
+.PARAMETER ExtendedLogicalChecks
+    Run extended logical checks. Y or N. Default: N.
+
+.PARAMETER TabLock
+    Use table locks during check. Y or N. Default: N.
+
+.PARAMETER MaxDOP
+    Max degree of parallelism for CHECKDB.
+
+.PARAMETER AvailabilityGroups
+    Ola @AvailabilityGroups filter.
+
+.PARAMETER AvailabilityGroupReplicas
+    Which AG replicas to check. Default: ALL.
+
+.PARAMETER Updateability
+    ALL, READ_WRITE, or READ_ONLY. Default: ALL.
+
+.PARAMETER TimeLimit
+    Maximum runtime in seconds.
+
+.PARAMETER LockTimeout
+    Lock wait timeout in seconds. Default: 10800 (3 hours).
+
+.PARAMETER DatabasesInParallel
+    Run checks on multiple databases in parallel. Y or N. Default: N.
+
+.EXAMPLE
+    .\Invoke-CentralIntegrityCheck.ps1 -SqlInstance 'SQL-01' -CMSInstanceName 'CMS-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run. No DBCC commands are executed.
+
+.EXAMPLE
+    .\Invoke-CentralIntegrityCheck.ps1 -CMSInstanceName 'CMS-01' -RunLocally -OutputPath 'D:\Logs'
+    MSX/TSX mode: CHECKDB on all databases on the local instance.
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : 2024-01-01
+    Version     : 4.1.0
+    Replaces    : CentralDB/Get-OlaHallengren-Integrity.ps1
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+                  Ola Hallengren maintenance solution (or -DeployOla Y)
+    Impact      : HIGH - runs DBCC CHECKDB, generates I/O load
+    Schedule    : Weekly via SQL Agent (recommended: off-peak weekend)
+
+    Permissions :
+        Target    : db_owner on checked databases, VIEW SERVER STATE
+        CentralDB : EXECUTE on [Svr].[usp_GetCollectionTargets]
+                    EXECUTE on [Svr].[usp_SetCollectionLastRun]
+                    INSERT on [Inst].[CommandLog]
+
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\share\CentralDB\Collect\Invoke-CentralIntegrityCheck.ps1"
+                        -CMSInstanceName "$(ESCAPE_DQUOTE(SRVR))"
+                        -RunLocally
+                        -OutputPath "D:\Logs\CentralDB"
+
+    Attribution:
+        DatabaseIntegrityCheck is created and maintained by Ola Hallengren.
+        https://ola.hallengren.com
+#>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [string[]]$SqlInstance,
+        [Parameter()][PSCredential]$SqlCredential,
+        [Parameter()][string]$CMSInstanceName,
+        [Parameter()][ValidateNotNullOrEmpty()][string]$CMSDatabaseName = 'CentralDB',
+        [Parameter()][ValidateRange(60, 86400)][int]$CommandTimeout = 14400,
+        [Parameter()][ValidateSet('Y', 'N')][string]$IntroduceDelay = 'N',
+        [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMin = 1,
+        [Parameter()][ValidateRange(1, 3600)][int]$DelaySecMax = 300,
+        [Parameter()][switch]$RunLocally,
+        [Parameter(Mandatory)][ValidateScript({ Test-Path $_ -PathType Container })][string]$OutputPath,
+        [Parameter()][ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')][string]$OutputFormat = 'CSV',
+        [Parameter()][string]$LoadGUID,
+        [Parameter()][ValidateSet('Y', 'N')][string]$DeployOla = 'N',
+        [Parameter()][ValidateNotNullOrEmpty()][string]$OlaDatabase = 'master',
+        [Parameter()][string]$Databases = 'ALL_DATABASES',
+        [Parameter()][ValidateSet('CHECKDB', 'CHECKFILEGROUP', 'CHECKTABLE', 'CHECKALLOC', 'CHECKCATALOG')][string]$CheckCommands = 'CHECKDB',
+        [Parameter()][ValidateSet('Y', 'N')][string]$PhysicalOnly = 'Y',
+        [Parameter()][ValidateSet('Y', 'N')][string]$NoIndex = 'N',
+        [Parameter()][ValidateSet('Y', 'N')][string]$ExtendedLogicalChecks = 'N',
+        [Parameter()][ValidateSet('Y', 'N')][string]$TabLock = 'N',
+        [Parameter()][int]$MaxDOP,
+        [Parameter()][string]$AvailabilityGroups,
+        [Parameter()][ValidateSet('ALL', 'PRIMARY', 'SECONDARY', 'PREFERRED_BACKUP_REPLICA')][string]$AvailabilityGroupReplicas = 'ALL',
+        [Parameter()][ValidateSet('ALL', 'READ_WRITE', 'READ_ONLY')][string]$Updateability = 'ALL',
+        [Parameter()][int]$TimeLimit,
+        [Parameter()][int]$LockTimeout = 10800,
+        [Parameter()][ValidateSet('Y', 'N')][string]$DatabasesInParallel = 'N'
+    )
+
+    begin {
+        #region Module Check
+        $SCRIPT_VERSION  = '4.1.0'
+        $requiredVersion = [Version]'2.0.0'
+        $dbatoolsMod     = Get-Module -Name dbatools -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+        if (-not $dbatoolsMod)                        { throw 'dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers' }
+        if ($dbatoolsMod.Version -lt $requiredVersion){ Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended." }
+        Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+        #endregion
+
+        #region Init
+        $ErrorActionPreference = 'Stop'
+        $Script:ErrorCount     = 0
+        $Script:WarningCount   = 0
+        $Script:Results        = New-Object 'System.Collections.Generic.List[PSCustomObject]'
+        $elapsedTime           = [System.Diagnostics.Stopwatch]::StartNew()
+        $stepName              = 'Initialization'
+        $collectedAt           = Get-Date
+        if ($LoadGUID) { $runGUID = $LoadGUID } else { $runGUID = [guid]::NewGuid().ToString() }
+        $credParam    = @{}; if ($SqlCredential) { $credParam['SqlCredential']    = $SqlCredential }
+        $cmsCredParam = @{}; if ($SqlCredential) { $cmsCredParam['SqlCredential'] = $SqlCredential }
+        #endregion
+
+        #region Helpers
+        function Write-DbaLog {
+            param([Parameter(Mandatory)][string]$Message, [ValidateSet('INFO','WARN','ERROR','DEBUG')][string]$Level = 'INFO')
+            $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+            switch ($Level) {
+                'INFO'  { Write-Verbose  "[$ts] [INFO]  $Message" }
+                'WARN'  { Write-Warning  "[$ts] [WARN]  $Message"; $Script:WarningCount++ }
+                'ERROR' { Write-Warning  "[$ts] [ERROR] $Message"; $Script:ErrorCount++ }
+                'DEBUG' { Write-Debug    "[$ts] [DEBUG] $Message" }
+            }
+        }
+        function Write-ToCms {
+            param([Parameter(Mandatory)][object]$Data, [Parameter(Mandatory)][string]$Table, [Parameter(Mandatory)][string]$Label)
+            try {
+                $Data | Write-DbaDbTableData -SqlInstance $CMSInstanceName -Database $CMSDatabaseName -Table $Table -AutoCreateTable @cmsCredParam -EnableException
+                Write-DbaLog "[$Label] Wrote $(@($Data).Count) row(s) to $Table"
+            }
+            catch { Write-DbaLog "[$Label] CMS write to $Table failed - $($_.Exception.Message)" -Level WARN } # Non-fatal
+        }
+        function Test-CMSConnection {
+            try { $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @cmsCredParam -ErrorAction Stop; return $true }
+            catch { return $false }
+        }
+        #endregion
+
+        Write-DbaLog "Invoke-CentralIntegrityCheck v$SCRIPT_VERSION started. LoadGUID: $runGUID | Command: $CheckCommands"
+
+        if ($IntroduceDelay -eq 'Y') {
+            $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+            Write-DbaLog "Stagger delay: $delay seconds."; Start-Sleep -Seconds $delay
+        }
+
+        #region Instance Discovery
+        $stepName = 'Instance Discovery'
+        if ($RunLocally) {
+            if (-not $CMSInstanceName) { throw '-CMSInstanceName is required when -RunLocally is specified.' }
+            if (-not (Test-CMSConnection)) { throw "CMS instance '$CMSInstanceName' is not reachable." }
+            $localHost = $env:COMPUTERNAME
+            $rows = Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                -Query 'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct, @RunLocally = 1, @LocalServerName = @sn' `
+                -SqlParameters @{ ct = 'Baseline'; sn = $localHost } -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+            $SqlInstance = @($rows | ForEach-Object { $sv=$_.ServerName; $in=$_.InstanceName; if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv } })
+        }
+        elseif ($CMSInstanceName -and (-not $SqlInstance)) {
+            if (-not (Test-CMSConnection)) { throw "CMS instance '$CMSInstanceName' is not reachable." }
+            $rows = Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                -Query 'EXEC [Svr].[usp_GetCollectionTargets] @CollectionType = @ct' `
+                -SqlParameters @{ ct = 'Baseline' } -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+            $SqlInstance = @($rows | ForEach-Object { $sv=$_.ServerName; $in=$_.InstanceName; if ($in -and $in -ne 'MSSQLSERVER') { "$sv\$in" } else { $sv } })
+        }
+        if (-not $SqlInstance -or $SqlInstance.Count -eq 0) { throw 'No target instances resolved.' }
+        #endregion
+    }
+
+    process {
+        $instanceErrors = New-Object 'System.Collections.Generic.List[string]'
+
+        foreach ($instance in $SqlInstance) {
+            $hostName     = ($instance -split '[\\,]')[0]
+            $instancePart = if ($instance -match '\\') { ($instance -split '\\')[1] } else { 'MSSQLSERVER' }
+            Write-DbaLog "=== Begin integrity check: $instance ($CheckCommands) ==="
+
+            try {
+                # Phase 1: Optional deploy
+                if ($DeployOla -eq 'Y') {
+                    $stepName = "Deploy Ola on $instance"
+                    if ($PSCmdlet.ShouldProcess($instance, 'Install/update Ola Hallengren maintenance solution')) {
+                        try {
+                            Install-DbaMaintenanceSolution -SqlInstance $instance -Database $OlaDatabase @credParam -EnableException | Out-Null
+                            Write-DbaLog "[Deploy] Ola installed/updated on $instance.$OlaDatabase"
+                        }
+                        catch { Write-DbaLog "[Deploy] Failed on $($instance) - $($_.Exception.Message)" -Level WARN }
+                    }
+                }
+
+                # Phase 2: Verify DatabaseIntegrityCheck exists
+                $stepName  = "Verify DatabaseIntegrityCheck on $instance"
+                $procCheck = Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                    -Query "SELECT COUNT(1) AS Cnt FROM sys.objects WHERE name = 'DatabaseIntegrityCheck' AND type = 'P'" `
+                    -CommandTimeout 60 @credParam -EnableException
+                if ($procCheck.Cnt -eq 0) {
+                    Write-DbaLog "[Integrity] DatabaseIntegrityCheck not found on $instance.$OlaDatabase. Use -DeployOla Y." -Level WARN
+                    $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.IntegrityResult'; SqlInstance=$instance; RowsCollected=0; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Skipped'; ErrorMessage="DatabaseIntegrityCheck not found on $OlaDatabase" })
+                    continue
+                }
+
+                # Phase 3: Build and execute DatabaseIntegrityCheck
+                $stepName = "Execute DatabaseIntegrityCheck on $instance"
+                if ($PSCmdlet.ShouldProcess($instance, "Execute $CheckCommands on $Databases")) {
+
+                    $olaParams  = "@Databases = '$Databases', @CheckCommands = '$CheckCommands', @LogToTable = 'Y', @Execute = 'Y'"
+                    $olaParams += ", @LoadGUID = '$runGUID'"
+                    $olaParams += ", @PhysicalOnly = '$PhysicalOnly'"
+                    $olaParams += ", @NoIndex = '$NoIndex'"
+                    $olaParams += ", @ExtendedLogicalChecks = '$ExtendedLogicalChecks'"
+                    $olaParams += ", @TabLock = '$TabLock'"
+                    $olaParams += ", @AvailabilityGroupReplicas = '$AvailabilityGroupReplicas'"
+                    $olaParams += ", @Updateability = '$Updateability'"
+                    $olaParams += ", @LockTimeout = $LockTimeout"
+                    $olaParams += ", @DatabasesInParallel = '$DatabasesInParallel'"
+                    if ($MaxDOP)             { $olaParams += ", @MaxDOP = $MaxDOP" }
+                    if ($AvailabilityGroups) { $olaParams += ", @AvailabilityGroups = '$AvailabilityGroups'" }
+                    if ($TimeLimit)          { $olaParams += ", @TimeLimit = $TimeLimit" }
+
+                    Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                        -Query "EXEC dbo.DatabaseIntegrityCheck $olaParams" `
+                        -CommandTimeout $CommandTimeout @credParam -EnableException | Out-Null
+                    Write-DbaLog "[Integrity] DatabaseIntegrityCheck completed on $instance"
+
+                    # Collect and centralize
+                    $logRows = Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                        -Query 'SELECT * FROM dbo.CommandLog WHERE LoadGUID = @lg' `
+                        -SqlParameters @{ lg = $runGUID } -CommandTimeout 60 @credParam -EnableException
+                    if ($logRows) {
+                        $enriched = $logRows | Select-Object @{ n='CollectionServerName'; e={ $hostName } }, @{ n='CollectionInstance'; e={ $instance } }, @{ n='LoadGUID'; e={ $runGUID } }, @{ n='CollectedAt'; e={ $collectedAt } }, *
+                        Write-ToCms -Data $enriched -Table '[Inst].[CommandLog]' -Label 'Integrity'
+                    }
+
+                    # Cleanup
+                    try {
+                        Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                            -Query 'DELETE FROM dbo.CommandLog WHERE LoadGUID = @lg' `
+                            -SqlParameters @{ lg = $runGUID } -CommandTimeout 60 @credParam -EnableException | Out-Null
+                        Invoke-DbaQuery -SqlInstance $instance -Database $OlaDatabase `
+                            -Query 'DELETE FROM dbo.CommandLog WHERE EndTime <= DATEADD(DAY, -1, GETDATE())' `
+                            -CommandTimeout 60 @credParam -EnableException | Out-Null
+                    }
+                    catch { Write-DbaLog "[Integrity] CommandLog cleanup failed on $($instance) - $($_.Exception.Message)" -Level WARN }
+
+                    $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.IntegrityResult'; SqlInstance=$instance; CheckCommands=$CheckCommands; RowsCollected=@($logRows).Count; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Success'; ErrorMessage=$null })
+                }
+
+                try {
+                    Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                        -Query 'EXEC [Svr].[usp_SetCollectionLastRun] @CollectionType = @ct, @ServerName = @sv, @InstanceName = @in, @LoadGUID = @lg' `
+                        -SqlParameters @{ ct='Baseline'; sv=$hostName; in=$instancePart; lg=$runGUID } `
+                        -CommandTimeout $CommandTimeout @cmsCredParam -EnableException
+                }
+                catch { Write-DbaLog "Failed to update collection timestamp for $($instance) - $($_.Exception.Message)" -Level WARN }
+
+                Write-DbaLog "=== Completed $instance ==="
+            }
+            catch {
+                $msg = "[$($stepName)] Failed on $($instance) - $($_.Exception.Message)"
+                $instanceErrors.Add($msg)
+                Write-DbaLog $msg -Level ERROR
+                $Script:Results.Add([PSCustomObject]@{ PSTypeName='CentralDB.IntegrityResult'; SqlInstance=$instance; CheckCommands=$CheckCommands; RowsCollected=0; LoadGUID=$runGUID; CollectedAt=$collectedAt; Status='Failed'; ErrorMessage=$_.Exception.Message })
+                continue
+            }
+        }
+
+        if ($instanceErrors.Count -gt 0) {
+            throw "Invoke-CentralIntegrityCheck completed with $($instanceErrors.Count) instance error(s):`n$($instanceErrors -join "`n")"
+        }
+    }
+
+    end {
+        $elapsedTime.Stop()
+        $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+        if ($Script:ErrorCount -gt 0) { Write-Warning "Invoke-CentralIntegrityCheck completed with $Script:ErrorCount error(s) in $duration." }
+        else { Write-DbaLog "Invoke-CentralIntegrityCheck completed successfully in $duration." }
+        $exportBase = Join-Path $OutputPath ("IntegrityCheck_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss')")
+        switch ($OutputFormat) {
+            'CSV'      { $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation }
+            'JSON'     { $Script:Results | ConvertTo-Json -Depth 5 | Out-File -FilePath "$exportBase.json" -Encoding utf8 }
+            'HTML'     { $Script:Results | ConvertTo-Html -Title 'CentralDB Integrity Check' | Out-File -FilePath "$exportBase.html" -Encoding utf8 }
+            'GridView' { $Script:Results | Out-GridView -Title 'CentralDB Integrity Check' }
+            'Excel'    {
+                if (Get-Module -Name ImportExcel -ListAvailable) { $Script:Results | Export-Excel -Path "$exportBase.xlsx" -AutoSize -FreezeTopRow }
+                else { Write-DbaLog 'ImportExcel not found - falling back to CSV.' -Level WARN; $Script:Results | Export-Csv -Path "$exportBase.csv" -NoTypeInformation }
+            }
+        }
+        Write-DbaLog "Output written to $exportBase.$($OutputFormat.ToLower())"
+        $Script:Results
+    }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') { $invokeParams[$key] = $PSBoundParameters[$key] }
+}
+Invoke-CentralIntegrityCheck @invokeParams -Confirm:$false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,237 @@
-CentralDB
-=========
+# CentralDB
 
-SQL Server Inventory and Baselining using Powershell and SSRS
+SQL Server estate management platform — collects, centralizes, and reports inventory, performance, and maintenance data across any number of instances using PowerShell and SSRS.
 
-So if you are already using this, please create a new DB using the script provided and then use visual studio data tools to compare the databases to see what needs to be changed... or if you are like me. Save the data from the svr.ServerList table and then blow away the database and create a fresh new database then import the data correctly to the Srv.ServerList Table.
+## What it does
+
+CentralDB runs scheduled PowerShell collection jobs on each SQL Server instance (or fleet-wide via a CMS master job). Each script collects data, writes it to a central SQL Server database (`CentralDB`), and produces a CSV/Excel output. SSRS reports surface the collected data for compliance, performance analysis, and capacity planning.
+
+## Architecture
+
+```
+SQL Agent (CmdExec)
+    │
+    ├─ Collect/Get-CentralInventory.ps1          ──► [Svr].[ServerInfo], [Inst].[*], [Db].[*], [HA].[*]
+    ├─ Collect/Get-CentralWaitStats.ps1          ──► [Inst].[WaitStats]
+    ├─ Collect/Get-CentralBaselineStats.ps1      ──► [Inst].[InsBaselineStats], [Svr].[SvrBaselineStats]
+    ├─ Collect/Invoke-CentralBlitzCollection.ps1 ──► [FRK].[Blitz]
+    ├─ Collect/Invoke-CentralBackup.ps1          ──► [Inst].[CommandLog]
+    ├─ Collect/Invoke-CentralIndexOptimize.ps1   ──► [Inst].[CommandLog]
+    └─ Collect/Invoke-CentralIntegrityCheck.ps1  ──► [Inst].[CommandLog]
+                                    │
+                              CentralDB (SQL Server)
+                                    │
+                          SSRS Reports (CentralDB_Reports/)
+```
+
+## Requirements
+
+| Component | Minimum version |
+|-----------|----------------|
+| PowerShell | 5.1 (Windows PowerShell) |
+| dbatools | 2.0.0 |
+| SQL Server (collection target) | 2012+ |
+| SQL Server (CentralDB host) | 2016+ recommended |
+
+## Quick Start
+
+### 1. Create CentralDB
+
+Run `CreateScript-NewCentralDB-Database.sql` against your central SQL Server instance. Then deploy the stored procedures in `SQL/StoredProcedures/` against `CentralDB`:
+
+```sql
+:r SQL\StoredProcedures\Svr.usp_GetCollectionTargets.sql
+:r SQL\StoredProcedures\Svr.usp_SetCollectionLastRun.sql
+:r SQL\StoredProcedures\Inst.usp_GetBaselineStats.sql
+```
+
+### 2. Register target instances
+
+```sql
+INSERT INTO [Svr].[ServerList] (ServerName, InstanceName, Active, Baseline)
+VALUES ('SQL-PROD-01', 'MSSQLSERVER', 1, 1),
+       ('SQL-PROD-02', 'INST1',       1, 1);
+```
+
+- `Active = 1` — included in Inventory collection
+- `Baseline = 1` — included in WaitStats and Baseline collections
+
+### 3. Install dbatools
+
+Run on every server that executes collection jobs:
+
+```powershell
+Install-Module dbatools -Scope AllUsers -MinimumVersion 2.0.0
+```
+
+### 4. Run a collection
+
+```powershell
+# Wait statistics from a single instance
+.\Collect\Get-CentralWaitStats.ps1 `
+    -SqlInstance 'SQL-PROD-01' `
+    -CMSInstanceName 'CMS-01' `
+    -OutputPath 'D:\Logs\CentralDB'
+
+# Full inventory from all active CMS-registered instances
+.\Collect\Get-CentralInventory.ps1 `
+    -CMSInstanceName 'CMS-01' `
+    -OutputPath 'D:\Logs\CentralDB' `
+    -Sections All
+```
+
+---
+
+## Collection Scripts
+
+### Get-CentralInventory.ps1
+
+Collects a full estate inventory across up to five sections. Run weekly or on-demand.
+
+| Section | Data collected | Platform |
+|---------|---------------|----------|
+| `ServerOS` | OS version, patches, page file, disk space, SQL services | Windows only |
+| `Instance` | SQL build/compliance, sp_configure, logins, linked servers, agent jobs | All |
+| `Databases` | DB properties, files, backup history, permissions, missing indexes | All |
+| `HA` | Availability groups, replicas, AG databases | All |
+| `SSRS` | Reporting Services instance info | Windows only |
+
+Use `-Sections Instance,Databases` to collect a subset rather than the full inventory.
+
+### Get-CentralWaitStats.ps1
+
+Collects `sys.dm_os_wait_stats` via `Get-DbaWaitStatistic`. Run every 15-30 minutes for trending.
+
+Optional: `-IncludeSystemWaits` to capture system waits in addition to application waits.
+
+### Get-CentralBaselineStats.ps1
+
+Captures SQL performance counter deltas (batch requests/sec, page life expectancy, lock waits, etc.) and OS PerfMon counters (CPU%, disk latency, available memory). Run every 5-15 minutes.
+
+Three collections per instance:
+- **SQL counters** — `[Inst].[usp_GetBaselineStats]` takes two DMV snapshots 1 second apart and returns a pivoted row
+- **OS baseline** — PerfMon counters via `Get-Counter` (Windows only)
+- **Drive baseline** — per-physical-drive PerfMon counters (Windows only)
+
+### Invoke-CentralBlitzCollection.ps1
+
+Runs `sp_Blitz` (First Responder Kit) and centralizes findings into `[FRK].[Blitz]`. Run daily or weekly.
+
+Set `-DeployFRK Y` to install or update the First Responder Kit on first run.
+
+### Invoke-CentralBackup.ps1
+
+Executes Ola Hallengren `DatabaseBackup` and centralizes `CommandLog` results.
+
+| Parameter | Values | Default |
+|-----------|--------|---------|
+| `-BackupType` | `FULL`, `DIFF`, `LOG` | `FULL` |
+| `-Databases` | `ALL_DATABASES`, `USER_DATABASES`, `SYSTEM_DATABASES`, or comma-separated list | `ALL_DATABASES` |
+| `-Compress` | `Y`, `N` | `Y` |
+| `-Verify` | `Y`, `N` | `Y` |
+| `-CopyOnly` | `Y`, `N` | `N` |
+| `-Encrypt` | `Y`, `N` | — |
+
+Set `-DeployOla Y` to install or update Ola's solution on first run.
+
+### Invoke-CentralIndexOptimize.ps1
+
+Executes Ola Hallengren `IndexOptimize` and centralizes `CommandLog` results. Schedule weekly for full rebuilds and nightly for reorganizes.
+
+Key parameters: `-FragmentationLevel1` (default 5%), `-FragmentationLevel2` (default 30%), `-TimeLimit` (seconds) to enforce a maintenance window, `-UpdateStatistics` for combined index+stats maintenance.
+
+### Invoke-CentralIntegrityCheck.ps1
+
+Executes Ola Hallengren `DatabaseIntegrityCheck` and centralizes `CommandLog` results.
+
+Key parameters: `-CheckCommands` (`CHECKDB`, `CHECKFILEGROUP`, `CHECKTABLE`, `CHECKALLOC`, `CHECKCATALOG`), `-PhysicalOnly Y` (default — faster, appropriate for scheduled checks), `-LockTimeout` (default 10800s), `-DatabasesInParallel` for faster fleet-wide runs.
+
+---
+
+## Common Parameters
+
+All scripts share this standard parameter set:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `-SqlInstance` | One or more target instances | — |
+| `-SqlCredential` | SQL auth (PSCredential — never plaintext) | Windows auth |
+| `-CMSInstanceName` | CentralDB instance for discovery + storage | — |
+| `-CMSDatabaseName` | CentralDB database name | `CentralDB` |
+| `-CommandTimeout` | Query timeout in seconds | 600 (or 14400 for maintenance ops) |
+| `-OutputPath` | Local directory for CSV/export output | Required |
+| `-OutputFormat` | `CSV`, `HTML`, `JSON`, `Excel`, `GridView` | `CSV` |
+| `-RunLocally` | CMS discovery restricted to the local machine (MSX/TSX jobs) | `$false` |
+| `-IntroduceDelay` | Random sleep before execution to stagger fleet writes (`Y`/`N`) | `N` |
+| `-DelaySecMin` / `-DelaySecMax` | Stagger delay bounds in seconds | `1` / `300` |
+| `-LoadGUID` | Correlation GUID for this run (auto-generated if omitted) | Auto |
+
+---
+
+## SQL Agent Job Configuration
+
+All jobs use the **CmdExec** step type — never the PowerShell step type (CmdExec returns correct exit codes).
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+    -File "\\FILESERVER\DBATools\CentralDB\Collect\<script>.ps1"
+    -CMSInstanceName "CMS-01"
+    -OutputPath "D:\Logs\CentralDB"
+    -RunLocally
+    -IntroduceDelay Y
+```
+
+For MSX/TSX multi-server jobs, use the SQL Agent `$(ESCAPE_DQUOTE(SRVR))` token instead of `-RunLocally`:
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+    -File "\\FILESERVER\DBATools\CentralDB\Collect\Get-CentralWaitStats.ps1"
+    -CMSInstanceName "CMS-01"
+    -SqlInstance "$(ESCAPE_DQUOTE(SRVR))"
+    -OutputPath "D:\Logs\CentralDB"
+```
+
+See [CentralDB-Ops-Runbook.md](CentralDB-Ops-Runbook.md) for full deployment steps and per-script job templates.
+
+---
+
+## SQL stored procedures
+
+| Object | Purpose |
+|--------|---------|
+| `Svr.usp_GetCollectionTargets` | Returns active instances from `[Svr].[ServerList]` filtered by collection type and optional local-machine filter |
+| `Svr.usp_SetCollectionLastRun` | Records last successful run timestamp per instance per collection type |
+| `Inst.usp_GetBaselineStats` | Two-snapshot DMV capture returning a single pivoted baseline row |
+
+---
+
+## SSRS Reports
+
+Deploy `CentralDB_Reports/` to SQL Server Reporting Services and point the shared data source (`SQLInventoryReports.rds`) at your CentralDB instance.
+
+| Report | Description |
+|--------|-------------|
+| Inventory Overview / Detail | Estate snapshot across all registered instances |
+| Instance Overview / Detail | Per-instance drill-down |
+| Instance Performance Analysis | Wait stats and baseline counter trending |
+| Compliance — Backup Age | Instances with backups overdue |
+| Compliance — DBCC | Instances where DBCC has not run recently |
+| Compliance — SQL Version Out of Date | Build-level compliance |
+| Database Growth Report | File size trending |
+| AlwaysOn Group / Replica / Database | AG health |
+| Instance Job / Failed Job | Agent job status |
+| Server Low Disk Space | Disk capacity alerts |
+
+---
+
+## Development Standards
+
+All scripts follow [powershell-dba-engineer-guidelines-v4.1.0.md](powershell-dba-engineer-guidelines-v4.1.0.md).
+
+Key requirements:
+- Dual-block pattern (script `param()` + function + auto-invoke) for SQL Agent CmdExec compatibility
+- dbatools >= 2.0.0 throughout — no raw `SqlClient`, no `Invoke-Sqlcmd`, no `SqlBulkCopy`
+- PS 5.1 compatible — no ternary, no null-coalescing, no `ForEach-Object -Parallel`
+- CMS write failures are non-fatal (WARN only) — a CMS outage never aborts collection
+- Error accumulation: one instance failure is logged and skipped; remaining instances continue
+- All SQL queries use `SqlParameters` — no string concatenation into query strings

--- a/SQL/StoredProcedures/Inst.usp_GetBaselineStats.sql
+++ b/SQL/StoredProcedures/Inst.usp_GetBaselineStats.sql
@@ -1,0 +1,239 @@
+-- ============================================================================
+-- Object   : [Inst].[usp_GetBaselineStats]
+-- Schema   : Inst
+-- Author   : DBA Engineering
+-- Created  : 2024-01-01
+-- Version  : 4.1.0
+-- Purpose  : Captures a point-in-time SQL Server performance counter baseline
+--            by taking two snapshots of sys.dm_os_performance_counters one
+--            second apart, computing per-second delta rates, and returning a
+--            single pivoted row per call.
+--
+--            Replaces the inline T-SQL in Get-BaselineStats.ps1 which embedded
+--            the full two-snapshot PIVOT logic as a string in PowerShell with
+--            string-interpolated server/instance names (SQL injection risk).
+--
+-- Parameters:
+--   @ServerName   - Hostname for the ServerName column in results
+--   @InstanceName - Instance identifier for the InstanceName column
+--
+-- Returns:
+--   Single row with one column per counter, suitable for direct bulk insert
+--   into [Inst].[InsBaselineStats] via Write-DbaDbTableData.
+--
+-- Notes:
+--   WAITFOR DELAY '00:00:01' is intentional - required for delta counters.
+--   Buffer/Procedure cache percentages use the standard ratio formula
+--   (value / base * 100.0), correcting the original script which erroneously
+--   added 100 to both calculations.
+-- ============================================================================
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER PROCEDURE [Inst].[usp_GetBaselineStats]
+    @ServerName   NVARCHAR(255),
+    @InstanceName NVARCHAR(255)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    IF @ServerName IS NULL OR LEN(LTRIM(RTRIM(@ServerName))) = 0
+        THROW 50001, '@ServerName is required.', 1;
+
+    IF @InstanceName IS NULL OR LEN(LTRIM(RTRIM(@InstanceName))) = 0
+        THROW 50002, '@InstanceName is required.', 1;
+
+    DECLARE @CounterPrefix NVARCHAR(30);
+    SET @CounterPrefix = CASE
+        WHEN @@SERVICENAME = 'MSSQLSERVER' THEN 'SQLServer:'
+        ELSE 'MSSQL$' + @@SERVICENAME + ':'
+    END;
+
+    -- Snapshot 1
+    SELECT
+        CAST(1 AS INT)          AS collection_instance,
+        [object_name],
+        counter_name,
+        instance_name,
+        cntr_value,
+        cntr_type,
+        CURRENT_TIMESTAMP       AS collection_time
+    INTO #perf_counters_init
+    FROM sys.dm_os_performance_counters
+    WHERE
+        (
+               (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Page life expectancy')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Lazy writes/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Page reads/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Page writes/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Readahead pages/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Checkpoint pages/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Free list stalls/sec')
+            OR (object_name = @CounterPrefix + 'Databases'         AND counter_name = 'Log Growths')
+            OR (object_name = @CounterPrefix + 'Databases'         AND counter_name = 'Transactions/sec')
+            OR (object_name = @CounterPrefix + 'General Statistics'AND counter_name = 'User Connections')
+            OR (object_name = @CounterPrefix + 'General Statistics'AND counter_name = 'Processes blocked')
+            OR (object_name = @CounterPrefix + 'Locks'             AND counter_name = 'Lock Waits/sec')
+            OR (object_name = @CounterPrefix + 'Locks'             AND counter_name = 'Number of Deadlocks/sec')
+            OR (object_name = @CounterPrefix + 'Locks'             AND counter_name = 'Lock Wait Time (ms)')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Forwarded Records/sec')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Index Searches/sec')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Full Scans/sec')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Page Splits/sec')
+            OR (object_name = @CounterPrefix + 'SQL Statistics'    AND counter_name = 'Batch Requests/sec')
+            OR (object_name = @CounterPrefix + 'SQL Statistics'    AND counter_name = 'SQL Compilations/sec')
+            OR (object_name = @CounterPrefix + 'SQL Statistics'    AND counter_name = 'SQL Re-Compilations/sec')
+            OR (object_name = @CounterPrefix + 'Latches'           AND counter_name = 'Latch Waits/sec')
+            OR (object_name = @CounterPrefix + 'Memory Manager'    AND counter_name = 'Memory Grants Pending')
+            OR (object_name = @CounterPrefix + 'Workload Group Stats' AND counter_name = 'CPU usage %')
+            OR (object_name = @CounterPrefix + 'Workload Group Stats' AND counter_name = 'CPU usage % base')
+        )
+    AND (instance_name = '' OR instance_name = '_Total' OR instance_name = 'default');
+
+    WAITFOR DELAY '00:00:01';
+
+    -- Snapshot 2
+    SELECT
+        CAST(2 AS INT)          AS collection_instance,
+        [object_name],
+        counter_name,
+        instance_name,
+        cntr_value,
+        cntr_type,
+        CURRENT_TIMESTAMP       AS collection_time
+    INTO #perf_counters_second
+    FROM sys.dm_os_performance_counters
+    WHERE
+        (
+               (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Page life expectancy')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Lazy writes/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Page reads/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Page writes/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Readahead pages/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Checkpoint pages/sec')
+            OR (object_name = @CounterPrefix + 'Buffer Manager'    AND counter_name = 'Free list stalls/sec')
+            OR (object_name = @CounterPrefix + 'Databases'         AND counter_name = 'Log Growths')
+            OR (object_name = @CounterPrefix + 'Databases'         AND counter_name = 'Transactions/sec')
+            OR (object_name = @CounterPrefix + 'General Statistics'AND counter_name = 'User Connections')
+            OR (object_name = @CounterPrefix + 'General Statistics'AND counter_name = 'Processes blocked')
+            OR (object_name = @CounterPrefix + 'Locks'             AND counter_name = 'Lock Waits/sec')
+            OR (object_name = @CounterPrefix + 'Locks'             AND counter_name = 'Number of Deadlocks/sec')
+            OR (object_name = @CounterPrefix + 'Locks'             AND counter_name = 'Lock Wait Time (ms)')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Forwarded Records/sec')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Index Searches/sec')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Full Scans/sec')
+            OR (object_name = @CounterPrefix + 'Access Methods'    AND counter_name = 'Page Splits/sec')
+            OR (object_name = @CounterPrefix + 'SQL Statistics'    AND counter_name = 'Batch Requests/sec')
+            OR (object_name = @CounterPrefix + 'SQL Statistics'    AND counter_name = 'SQL Compilations/sec')
+            OR (object_name = @CounterPrefix + 'SQL Statistics'    AND counter_name = 'SQL Re-Compilations/sec')
+            OR (object_name = @CounterPrefix + 'Latches'           AND counter_name = 'Latch Waits/sec')
+            OR (object_name = @CounterPrefix + 'Memory Manager'    AND counter_name = 'Memory Grants Pending')
+            OR (object_name = @CounterPrefix + 'Workload Group Stats' AND counter_name = 'CPU usage %')
+            OR (object_name = @CounterPrefix + 'Workload Group Stats' AND counter_name = 'CPU usage % base')
+        )
+    AND (instance_name = '' OR instance_name = '_Total' OR instance_name = 'default');
+
+    -- Buffer cache hit ratio (corrected: value/base*100, not 100+(delta/base*100))
+    DECLARE @BufferCachePct   DECIMAL(8, 2);
+    DECLARE @ProcedureCachePct DECIMAL(8, 2);
+
+    SELECT @BufferCachePct =
+        CAST(c.cntr_value AS FLOAT) / NULLIF(CAST(b.cntr_value AS FLOAT), 0) * 100.0
+    FROM sys.dm_os_performance_counters AS c
+    CROSS JOIN sys.dm_os_performance_counters AS b
+    WHERE c.object_name = @CounterPrefix + 'Buffer Manager'
+      AND c.counter_name = 'Buffer cache hit ratio'
+      AND b.object_name  = @CounterPrefix + 'Buffer Manager'
+      AND b.counter_name = 'Buffer cache hit ratio base';
+
+    SELECT @ProcedureCachePct =
+        CAST(c.cntr_value AS FLOAT) / NULLIF(CAST(b.cntr_value AS FLOAT), 0) * 100.0
+    FROM sys.dm_os_performance_counters AS c
+    CROSS JOIN sys.dm_os_performance_counters AS b
+    WHERE c.instance_name = '_Total'
+      AND c.object_name   = @CounterPrefix + 'Plan Cache'
+      AND c.counter_name  = 'Cache Hit Ratio'
+      AND b.instance_name = '_Total'
+      AND b.object_name   = @CounterPrefix + 'Plan Cache'
+      AND b.counter_name  = 'Cache Hit Ratio Base';
+
+    -- Delta calculation and PIVOT
+    SELECT
+        @ServerName             AS ServerName,
+        @InstanceName           AS InstanceName,
+        GETDATE()               AS CollectedAt,
+        [Forwarded Records/sec] AS FwdRecSec,
+        [Full Scans/sec]        AS FlScansSec,
+        [Index Searches/sec]    AS IdxSrchsSec,
+        [Page Splits/sec]       AS PgSpltSec,
+        [Free list stalls/sec]  AS FreeLstStallsSec,
+        [Lazy writes/sec]       AS LzyWrtsSec,
+        [Page life expectancy]  AS PgLifeExp,
+        [Page reads/sec]        AS PgRdSec,
+        [Page writes/sec]       AS PgWtSec,
+        [Log Growths]           AS LogGrwths,
+        [Transactions/sec]      AS TranSec,
+        [Processes blocked]     AS BlkProcs,
+        [User Connections]      AS UsrConns,
+        [Latch Waits/sec]       AS LatchWtsSec,
+        [Lock Wait Time (ms)]   AS LckWtTime,
+        [Lock Waits/sec]        AS LckWtsSec,
+        [Number of Deadlocks/sec] AS DeadLockSec,
+        [Memory Grants Pending] AS MemGrnts,
+        [Batch Requests/sec]    AS BatReqSec,
+        [SQL Compilations/sec]  AS SQLCompSec,
+        [SQL Re-Compilations/sec] AS SQLReCompSec,
+        [Readahead pages/sec]   AS ReadAheadReadsSec,
+        [Checkpoint pages/sec]  AS CheckpointWritesSec,
+        @BufferCachePct         AS BufferCachePercentage,
+        @ProcedureCachePct      AS ProcedureCachePercentage
+    FROM (
+        SELECT
+            s.counter_name,
+            CASE
+                WHEN i.cntr_type = 272696576 THEN s.cntr_value - i.cntr_value   -- per-sec delta
+                WHEN i.cntr_type = 65792     THEN s.cntr_value                  -- point-in-time
+                ELSE i.cntr_value
+            END AS cntr_value
+        FROM #perf_counters_init    AS i
+        JOIN #perf_counters_second  AS s
+            ON  i.collection_instance + 1 = s.collection_instance
+            AND i.object_name             = s.object_name
+            AND i.counter_name            = s.counter_name
+            AND i.instance_name           = s.instance_name
+    ) AS src
+    PIVOT (
+        MAX(cntr_value)
+        FOR counter_name IN (
+            [Forwarded Records/sec],
+            [Full Scans/sec],
+            [Index Searches/sec],
+            [Page Splits/sec],
+            [Free list stalls/sec],
+            [Lazy writes/sec],
+            [Page life expectancy],
+            [Page reads/sec],
+            [Page writes/sec],
+            [Log Growths],
+            [Transactions/sec],
+            [Processes blocked],
+            [User Connections],
+            [Latch Waits/sec],
+            [Lock Wait Time (ms)],
+            [Lock Waits/sec],
+            [Number of Deadlocks/sec],
+            [Memory Grants Pending],
+            [Batch Requests/sec],
+            [SQL Compilations/sec],
+            [SQL Re-Compilations/sec],
+            [Readahead pages/sec],
+            [Checkpoint pages/sec]
+        )
+    ) AS pvt;
+
+    DROP TABLE #perf_counters_init;
+    DROP TABLE #perf_counters_second;
+END;
+GO

--- a/SQL/StoredProcedures/Svr.usp_GetCollectionTargets.sql
+++ b/SQL/StoredProcedures/Svr.usp_GetCollectionTargets.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- Object   : [Svr].[usp_GetCollectionTargets]
+-- Schema   : Svr
+-- Author   : DBA Engineering
+-- Created  : 2024-01-01
+-- Version  : 4.1.0
+-- Purpose  : Returns the list of SQL Server instances to collect data from.
+--            Replaces all inline SELECT queries from [Svr].[ServerList] that
+--            were previously embedded in PowerShell collection scripts.
+--
+-- Parameters:
+--   @CollectionType  - Filter by collection flag column.
+--                      Supported values: 'WaitStats', 'Baseline', 'Inventory'
+--   @RunLocally      - 1 = restrict to @LocalServerName only (MSX/TSX jobs)
+--   @LocalServerName - The hostname to filter on when @RunLocally = 1
+--
+-- Result set: ServerName, InstanceName
+-- ============================================================================
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER PROCEDURE [Svr].[usp_GetCollectionTargets]
+    @CollectionType     NVARCHAR(50),
+    @RunLocally         BIT           = 0,
+    @LocalServerName    NVARCHAR(255) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    IF @CollectionType IS NULL OR LEN(LTRIM(RTRIM(@CollectionType))) = 0
+        THROW 50001, '@CollectionType is required.', 1;
+
+    IF @RunLocally = 1 AND (@LocalServerName IS NULL OR LEN(LTRIM(RTRIM(@LocalServerName))) = 0)
+        THROW 50002, '@LocalServerName is required when @RunLocally = 1.', 1;
+
+    SELECT DISTINCT
+        sl.ServerName,
+        sl.InstanceName
+    FROM [Svr].[ServerList] AS sl
+    WHERE sl.Active       = 1
+    AND   (
+              (@CollectionType = 'WaitStats'  AND sl.Baseline    = 1)
+           OR (@CollectionType = 'Baseline'   AND sl.Baseline    = 1)
+           OR (@CollectionType = 'Inventory'  AND sl.Active      = 1)
+          )
+    AND   (@RunLocally = 0 OR sl.ServerName = @LocalServerName)
+    ORDER BY
+        sl.ServerName,
+        sl.InstanceName;
+END;
+GO

--- a/SQL/StoredProcedures/Svr.usp_SetCollectionLastRun.sql
+++ b/SQL/StoredProcedures/Svr.usp_SetCollectionLastRun.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- Object   : [Svr].[usp_SetCollectionLastRun]
+-- Schema   : Svr
+-- Author   : DBA Engineering
+-- Created  : 2024-01-01
+-- Version  : 4.1.0
+-- Purpose  : Records the timestamp of the most recent successful collection
+--            run against a given instance. Called after each successful
+--            collection by the PowerShell scripts.
+--
+-- Parameters:
+--   @CollectionType  - The type of collection just completed.
+--                      Supported values: 'WaitStats', 'Baseline', 'Inventory'
+--   @ServerName      - The server hostname collected from.
+--   @InstanceName    - The SQL instance name collected from.
+--   @LoadGUID        - Correlation GUID from the calling script run.
+--
+-- Notes:
+--   Non-throwing - unknown ServerName/InstanceName combinations are silently
+--   ignored so that a missing registration never kills a collection run.
+-- ============================================================================
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER PROCEDURE [Svr].[usp_SetCollectionLastRun]
+    @CollectionType     NVARCHAR(50),
+    @ServerName         NVARCHAR(255),
+    @InstanceName       NVARCHAR(255),
+    @LoadGUID           NVARCHAR(36) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    IF @CollectionType IS NULL OR LEN(LTRIM(RTRIM(@CollectionType))) = 0
+        THROW 50001, '@CollectionType is required.', 1;
+
+    IF @ServerName IS NULL OR LEN(LTRIM(RTRIM(@ServerName))) = 0
+        THROW 50002, '@ServerName is required.', 1;
+
+    IF @InstanceName IS NULL OR LEN(LTRIM(RTRIM(@InstanceName))) = 0
+        THROW 50003, '@InstanceName is required.', 1;
+
+    UPDATE [Svr].[ServerList]
+    SET
+        WaitStatLastExecDate  = CASE WHEN @CollectionType = 'WaitStats'  THEN SYSDATETIME() ELSE WaitStatLastExecDate  END,
+        BaselineLastExecDate  = CASE WHEN @CollectionType = 'Baseline'   THEN SYSDATETIME() ELSE BaselineLastExecDate  END,
+        InventoryLastExecDate = CASE WHEN @CollectionType = 'Inventory'  THEN SYSDATETIME() ELSE InventoryLastExecDate END,
+        LastLoadGUID          = ISNULL(@LoadGUID, LastLoadGUID),
+        LastUpdated           = SYSDATETIME()
+    WHERE
+        ServerName   = @ServerName
+    AND InstanceName = @InstanceName;
+
+    -- Non-throwing: if no rows updated, the server simply wasn't registered
+END;
+GO

--- a/powershell-dba-engineer-guidelines-v4.1.0.md
+++ b/powershell-dba-engineer-guidelines-v4.1.0.md
@@ -1,0 +1,778 @@
+---
+name: powershell-dba-engineer
+description: >
+  PowerShell DBA engineer that develops standardized, validated SQL Server automation
+  scripts using dbatools, enforcing consistent coding standards, security practices,
+  error handling, and operational documentation from business requirements.
+version: 4.1.0
+---
+
+# PowerShell DBA Engineer - Development Guidelines v4.1.0
+
+> Production-hardened standards derived from enterprise modernization across a 1,400-instance
+> SQL Server estate including Ola Hallengren maintenance wrappers, compliance validation,
+> TDE enablement, SQL Audit deployment, AG failover, database migration, restore, and patching.
+
+---
+
+## 0. Before Any Work
+
+ALWAYS read the input provided in full before beginning development. The input will be one of:
+- **Operational requirements** - narrative descriptions of a DBA task, maintenance process, or automation need
+- **Script specifications** - structured or semi-structured lists of parameters, targets, outputs, or behaviors
+- **Existing scripts** - PowerShell code to review, refactor, or extend
+
+Never contradict constraints defined in project documentation. If no project documents exist, proceed using the input provided.
+
+---
+
+## 1. Script Architecture
+
+### 1.1 Dual-Block Pattern (Script + Function + Auto-Invoke)
+
+Every script MUST use this three-part structure to support both SQL Agent CmdExec execution
+and direct PowerShell invocation:
+
+```powershell
+# ============================================================================
+# PART 1 - Script-level parameter block
+#           Enables: powershell.exe -File script.ps1 -Param Value
+# ============================================================================
+[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+param (
+    [Parameter(Mandatory)][string[]]$SqlInstance,
+    [Parameter()][PSCredential]$SqlCredential
+    # ... all parameters mirrored from the function below
+)
+
+# ============================================================================
+# PART 2 - Advanced function definition
+# ============================================================================
+function Invoke-DbaTargetNoun {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        # ... identical parameter set with full validation attributes
+    )
+    begin   { }
+    process { }
+    end     { }
+}
+
+# ============================================================================
+# PART 3 - AUTO-INVOCATION: forwards script params to the function
+# ============================================================================
+$invokeParams = @{}
+foreach ($key in $PSBoundParameters.Keys) {
+    if ($key -notin 'Confirm', 'WhatIf') {
+        $invokeParams[$key] = $PSBoundParameters[$key]
+    }
+}
+Invoke-DbaTargetNoun @invokeParams -Confirm:$false
+```
+
+**Why this pattern:**
+- SQL Agent CmdExec runs `powershell.exe -File script.ps1 -Param Value` - requires a script-level `param()` block
+- Advanced functions cannot be invoked from a `-File` call without being loaded first
+- The auto-invoke block bridges the gap: script params -> function params -> execution
+- `-Confirm:$false` suppresses ShouldProcess prompts in non-interactive SQL Agent sessions
+- Filtering out `Confirm` and `WhatIf` from `$PSBoundParameters` avoids positional binding errors
+
+### 1.2 Function Naming
+
+Use approved PowerShell verbs. Common DBA mappings:
+
+| Verb       | Example                          | Use Case                          |
+|------------|----------------------------------|-----------------------------------|
+| `Invoke-`  | `Invoke-OlaHallengrenBackup`     | Execute a maintenance operation   |
+| `Enable-`  | `Enable-SqlServerTDE`            | Turn on a feature/capability      |
+| `Get-`     | `Get-DbaInventory`               | Read-only data collection         |
+| `Set-`     | `Set-DbaDbLoginPermission`       | Modify a setting or permission    |
+| `Test-`    | `Test-DbaCompliance`             | Validate / check status           |
+| `Restore-` | `Restore-DatabaseFromPath`       | Restore from backup               |
+| `Install-` | `Install-DSCPreRequisites`       | Bootstrap / install components    |
+
+### 1.3 ConfirmImpact Levels
+
+| Level    | Use When                                                         |
+|----------|------------------------------------------------------------------|
+| `High`   | Modifying data, patching, failover, encryption, AG operations    |
+| `Medium` | Installing modules, registering repositories, system config      |
+| `Low`    | Pure read operations, reporting                                  |
+
+---
+
+## 2. Parameters
+
+### 2.1 Standard Parameter Set
+
+```powershell
+param (
+    # Target instances - direct or pipeline
+    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+    [string[]]$SqlInstance,
+
+    # SQL authentication - never plaintext
+    [Parameter()]
+    [PSCredential]$SqlCredential,
+
+    # CMS-driven targeting
+    [Parameter()]
+    [string]$CMSInstanceName,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$CMSDatabaseName = 'CentralDB',
+
+    # Timeout
+    [Parameter()]
+    [ValidateRange(60, 86400)]
+    [int]$CommandTimeout = 600,
+
+    # MSX/TSX stagger support
+    [Parameter()]
+    [ValidateSet('Y', 'N')]
+    [string]$IntroduceDelay = 'N',
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMin = 1,
+
+    [Parameter()]
+    [ValidateRange(1, 3600)]
+    [int]$DelaySecMax = 300,
+
+    # CMS filter - only run on local instance (for MSX/TSX jobs)
+    [Parameter()]
+    [switch]$RunLocally,
+
+    # Output
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$OutputPath,
+
+    [Parameter()]
+    [ValidateSet('CSV', 'HTML', 'JSON', 'Excel', 'GridView')]
+    [string]$OutputFormat = 'CSV'
+)
+```
+
+### 2.2 Parameter Rules
+
+- Use `[string[]]` for SQL instance parameters - NOT `[DbaInstanceParameter[]]` (PS 5.1 compatibility)
+- Use `[PSCredential]` for all credential parameters - never plaintext passwords
+- Use `[ValidateSet('Y', 'N')]` instead of `[switch]` for parameters that flow through SQL Agent job steps
+- Always provide sensible defaults; `Mandatory` only for params that truly have no default
+- Build credential splatting in `begin` block:
+
+```powershell
+$credParam = @{}
+if ($SqlCredential) { $credParam['SqlCredential'] = $SqlCredential }
+```
+
+### 2.3 Instance Name Parsing
+
+After moving away from `[DbaInstanceParameter]`, parse instance names explicitly when needed:
+
+```powershell
+# Extract host from instance string (handles HOSTNAME, HOSTNAME\INSTANCE, HOSTNAME,PORT)
+$hostName = ($SqlInstance -split '[\\,]')[0]
+```
+
+---
+
+## 3. Comment-Based Help
+
+Every function MUST include full comment-based help. All fields below are required:
+
+```powershell
+<#
+.SYNOPSIS
+    One-line description.
+
+.DESCRIPTION
+    Multi-paragraph description including:
+    - What it automates step by step
+    - Key capabilities
+    - CMS operations behavior (non-fatal)
+    - Error handling approach
+    - Idempotency notes
+
+.PARAMETER SqlInstance
+    Description of each parameter, format hints, and examples.
+    Repeat .PARAMETER for every parameter.
+
+.EXAMPLE
+    .\Script.ps1 -SqlInstance 'SQL-01' -OutputPath 'D:\Logs' -WhatIf
+    Dry-run description.
+
+.EXAMPLE
+    .\Script.ps1 -CMSInstanceName 'CMS01' -RunLocally -IntroduceDelay Y -OutputPath 'D:\Logs'
+    MSX/TSX staggered CMS execution example.
+
+.NOTES
+    Author      : DBA Engineering
+    Created     : yyyy-MM-dd
+    Version     : 4.1.0
+    Requirements: dbatools >= 2.0.0, PowerShell >= 5.1
+    Impact      : HIGH - brief description of what changes
+    Schedule    : Ad-hoc | Daily | Weekly via SQL Agent
+    Permissions :
+        Target  : sysadmin or db_owner on target databases
+        CMS     : db_datareader on CentralDB, db_datawriter on CentralDB
+    SQL Agent Config :
+        Job Step Type : CmdExec
+        Run As        : Proxy 'DBA_Automation_Proxy'
+        Command       : powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass
+                        -File "\\path\to\script.ps1" -Param1 Value1
+#>
+```
+
+---
+
+## 4. Begin / Process / End Block Structure
+
+### 4.1 Begin Block
+
+```powershell
+begin {
+    #region Module Dependency Check
+    $SCRIPT_VERSION = '4.1.0'
+    $requiredVersion = [Version]'2.0.0'
+    $dbatoolsMod = Get-Module -Name dbatools -ListAvailable |
+        Sort-Object Version -Descending | Select-Object -First 1
+    if (-not $dbatoolsMod) {
+        throw "dbatools is not installed. Install via: Install-Module dbatools"
+    }
+    if ($dbatoolsMod.Version -lt $requiredVersion) {
+        Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended."
+    }
+    Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+    #endregion
+
+    #region Initialization
+    $ErrorActionPreference = 'Stop'
+    $Script:ErrorCount   = 0
+    $Script:WarningCount = 0
+    $Script:Results      = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $elapsedTime         = [System.Diagnostics.Stopwatch]::StartNew()
+    $stepName            = 'Initialization'
+    $LoadGUID            = if ($LoadGUID) { $LoadGUID } else { [guid]::NewGuid().ToString() }
+    #endregion
+
+    #region Credential Splat
+    $credParam = @{}
+    if ($SqlCredential) { $credParam['SqlCredential'] = $SqlCredential }
+    #endregion
+
+    #region Write-DbaLog Helper
+    function Write-DbaLog {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory)]
+            [string]$Message,
+
+            [Parameter()]
+            [ValidateSet('INFO', 'WARN', 'ERROR', 'DEBUG')]
+            [string]$Level = 'INFO'
+        )
+        $ts    = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+        $entry = "[$ts] [$Level] $Message"
+        switch ($Level) {
+            'INFO'  { Write-Verbose $entry }
+            'WARN'  { Write-Warning $entry; $Script:WarningCount++ }
+            'ERROR' { Write-Warning "ERROR: $Message"; $Script:ErrorCount++ }
+            'DEBUG' { Write-Debug $entry }
+        }
+    }
+    #endregion
+
+    Write-DbaLog "Script v$SCRIPT_VERSION started. LoadGUID: $LoadGUID"
+}
+```
+
+### 4.2 Process Block
+
+```powershell
+process {
+    $instanceErrors = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($instance in $SqlInstance) {
+        $stepName = "Connecting to $instance"
+        try {
+            # work here - update $stepName before each major step
+
+            $stepName = "Main operation on $instance"
+            # ...
+
+            $Script:Results.Add([PSCustomObject]@{
+                PSTypeName  = 'DbaTools.OperationResult'
+                SqlInstance = $instance
+                Status      = 'Success'
+                LoadGUID    = $LoadGUID
+                CompletedAt = Get-Date
+            })
+        }
+        catch {
+            $msg = "[$stepName] Failed on ${instance}: $($_.Exception.Message)"
+            $instanceErrors.Add($msg)
+            Write-DbaLog $msg -Level ERROR
+            continue   # process next instance
+        }
+    }
+
+    # CRITICAL: throw aggregated errors so SQL Agent sees FAILURE
+    if ($instanceErrors.Count -gt 0) {
+        $summary = $instanceErrors -join "`n"
+        throw "Completed with $($instanceErrors.Count) error(s):`n$summary"
+    }
+}
+```
+
+### 4.3 End Block
+
+```powershell
+end {
+    $elapsedTime.Stop()
+    $duration = $elapsedTime.Elapsed.ToString('hh\:mm\:ss')
+
+    if ($Script:ErrorCount -gt 0) {
+        Write-Warning "Script completed with $Script:ErrorCount error(s) in $duration. Review log."
+    }
+    else {
+        Write-DbaLog "Script completed successfully in $duration."
+    }
+
+    # Output results to pipeline
+    $Script:Results
+}
+```
+
+---
+
+## 5. Error Handling
+
+### 5.1 Error Accumulation Pattern
+
+Scripts that process multiple instances MUST accumulate errors and throw at the end:
+- One instance failure does NOT abort processing of remaining instances
+- SQL Agent job correctly reports FAILURE (a caught-and-swallowed error reports success)
+
+See §4.2 for the canonical pattern.
+
+### 5.2 CMS / CentralDB Operations are Non-Fatal
+
+All CMS operations - writing to ServerList, centralizing data - MUST use WARN, never throw:
+
+```powershell
+$stepName = "Centralizing results to CMS"
+try {
+    Write-DbaDbTableData -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+        -Table 'OperationResults' -InputObject $dt -EnableException
+    Write-DbaLog "Centralized $(@($dt).Count) row(s) to CMS."
+}
+catch {
+    Write-DbaLog "CMS centralization failed: $($_.Exception.Message)" -Level WARN
+    # Do NOT throw - CMS failure must never kill the script
+}
+```
+
+### 5.3 Step Name Tracking
+
+Always update `$stepName` immediately before each logical step so catch blocks have context:
+
+```powershell
+$stepName = "Deploying audit specification to $instance"
+try {
+    Invoke-DbaQuery -SqlInstance $instance -Query $deployQuery @credParam -EnableException
+}
+catch {
+    Write-DbaLog "Failed at step '$stepName': $($_.Exception.Message)" -Level ERROR
+}
+```
+
+---
+
+## 6. Instance Discovery (CMS-Driven)
+
+```powershell
+begin {
+    # Test CMS connectivity
+    function Test-CMSConnection {
+        try {
+            $null = Connect-DbaInstance -SqlInstance $CMSInstanceName @credParam -ErrorAction Stop
+            return $true
+        }
+        catch { return $false }
+    }
+}
+
+process {
+    # Resolve target instances
+    if ($RunLocally) {
+        # Resolve local instance from SQL Agent parent process
+        $agentPID = (Get-WmiObject Win32_Process -Filter "ProcessId=$PID").ParentProcessId
+        $agentSvc = Get-WmiObject Win32_Service | Where-Object { $_.ProcessId -eq $agentPID }
+        $localInstance = if ($agentSvc.Name -eq 'SQLSERVERAGENT') {
+            $env:COMPUTERNAME
+        }
+        else {
+            "$env:COMPUTERNAME\$($agentSvc.Name -replace 'SQLAgent\$', '')"
+        }
+        $SqlInstance = @($localInstance)
+    }
+    elseif ($CMSInstanceName -and -not $SqlInstance) {
+        # Pull from CMS ServerList
+        if (Test-CMSConnection) {
+            $query = "SELECT DISTINCT ServerName, InstanceName FROM Svr.ServerList WHERE Active = 1"
+            $serverRows = Invoke-DbaQuery -SqlInstance $CMSInstanceName -Database $CMSDatabaseName `
+                -Query $query @credParam -EnableException
+            $SqlInstance = $serverRows | ForEach-Object {
+                if ($_.InstanceName -and $_.InstanceName -ne 'MSSQLSERVER') {
+                    "$($_.ServerName)\$($_.InstanceName)"
+                }
+                else { $_.ServerName }
+            }
+        }
+        else {
+            throw "CMS instance '$CMSInstanceName' is not reachable."
+        }
+    }
+}
+```
+
+### 6.1 IntroduceDelay (MSX/TSX Staggering)
+
+```powershell
+if ($IntroduceDelay -eq 'Y') {
+    $delay = Get-Random -Minimum $DelaySecMin -Maximum $DelaySecMax
+    Write-DbaLog "Stagger delay: sleeping $delay seconds."
+    Start-Sleep -Seconds $delay
+}
+```
+
+---
+
+## 7. dbatools Patterns
+
+### 7.1 Always Use dbatools - Never Raw SqlClient
+
+| Avoid                                           | Use Instead                         |
+|-------------------------------------------------|-------------------------------------|
+| `New-Object System.Data.SqlClient.SqlConnection`| `Connect-DbaInstance`               |
+| `Invoke-Sqlcmd`                                 | `Invoke-DbaQuery`                   |
+| `$bulkCopy.WriteToServer($dt)`                  | `Write-DbaDbTableData`              |
+| `[System.Reflection.Assembly]::Load*('SMO')`    | Not needed - dbatools handles SMO   |
+| `Invoke-Expression $someString`                 | Direct cmdlet call                  |
+
+### 7.2 SQL Parameter Safety
+
+Never concatenate values into query strings. Always use SqlParameters:
+
+```powershell
+# WRONG - SQL injection risk
+Invoke-DbaQuery -SqlInstance $inst -Query "SELECT * FROM dbo.T WHERE Name = '$name'"
+
+# CORRECT
+Invoke-DbaQuery -SqlInstance $inst -Database 'master' -EnableException `
+    -Query "SELECT * FROM dbo.T WHERE Name = @Name" `
+    -SqlParameters @{ Name = $name }
+```
+
+### 7.3 Module Version Check Pattern (Begin Block)
+
+```powershell
+$requiredVersion = [Version]'2.0.0'
+$dbatoolsMod = Get-Module -Name dbatools -ListAvailable |
+    Sort-Object Version -Descending | Select-Object -First 1
+if (-not $dbatoolsMod) {
+    throw "dbatools is not installed. Run: Install-Module dbatools -Scope AllUsers"
+}
+if ($dbatoolsMod.Version -lt $requiredVersion) {
+    Write-Warning "dbatools $($dbatoolsMod.Version) found; >= $requiredVersion recommended."
+}
+Import-Module dbatools -MinimumVersion $requiredVersion -ErrorAction Stop
+```
+
+---
+
+## 8. Output Standards
+
+### 8.1 Result Objects
+
+Every script MUST output structured `[PSCustomObject]` results to the pipeline:
+
+```powershell
+[PSCustomObject]@{
+    PSTypeName         = 'DbaTools.OperationResult'
+    SqlInstance        = $instance
+    DatabaseName       = $db
+    OperationType      = 'FULL'
+    LoadGUID           = $LoadGUID
+    Status             = 'Success'
+    CompletedAt        = Get-Date
+    ElapsedTime        = $elapsedTime.Elapsed.ToString()
+    ErrorCount         = $Script:ErrorCount
+    WarningCount       = $Script:WarningCount
+}
+```
+
+### 8.2 Output Formats
+
+Support configurable export via `$OutputFormat` parameter:
+
+| Format      | Implementation                                |
+|-------------|-----------------------------------------------|
+| `CSV`       | `Export-Csv -NoTypeInformation`               |
+| `Excel`     | `Export-Excel` (ImportExcel module)           |
+| `HTML`      | `ConvertTo-Html` with styled table            |
+| `JSON`      | `ConvertTo-Json -Depth 5`                     |
+| `GridView`  | `Out-GridView` (interactive sessions only)    |
+
+Always emit results to pipeline at end of `end {}` block regardless of `$OutputFormat`.
+
+### 8.3 Banned Output Commands
+
+- `Write-Output` - pollutes the pipeline with log noise
+- `Write-Host` - bypasses pipeline entirely
+- `Format-Table` / `ft` - destroys structured objects; never use in scripts
+
+---
+
+## 9. Security
+
+### 9.1 Credentials
+
+- Always use `[PSCredential]` - never plaintext passwords
+- Document required permissions in `.NOTES` under `Permissions`
+- Use least-privilege service accounts for SQL Agent proxy
+
+### 9.2 Execution Policy
+
+Never call `Set-ExecutionPolicy` at runtime inside a script. Use `-ExecutionPolicy Bypass` on the SQL Agent CmdExec command line.
+
+### 9.3 Connection Security
+
+```powershell
+# Handle self-signed certs in dev/test environments if needed
+# Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -Register
+```
+
+---
+
+## 10. PS 5.1 Compatibility
+
+All scripts MUST run on Windows PowerShell 5.1. The following constructs are BANNED:
+
+| Banned Construct                     | PS 5.1 Alternative                          |
+|--------------------------------------|---------------------------------------------|
+| Ternary `$a ? $b : $c`              | `if ($a) { $b } else { $c }`               |
+| Null-coalescing `$a ?? $b`           | `if ($null -ne $a) { $a } else { $b }`     |
+| Null-conditional `$a?.Property`      | `if ($null -ne $a) { $a.Property }`        |
+| Pipeline chains `&&` / `\|\|`        | Separate statements with try/catch          |
+| `ForEach-Object -Parallel`           | Standard `foreach` loop                    |
+| `$PSBoundParameters.Clone()`         | Manual hashtable copy                      |
+| `[DbaInstanceParameter]` type        | `[string[]]`                               |
+| `::new()` constructor                | `New-Object` or cast                       |
+| `clean {}` block                     | Not available - use `end {}`               |
+| Here-string `@" ... "@` mid-indent   | String concatenation or `-f` format        |
+| Em dash in strings/comments          | Plain hyphen `-`                           |
+| UTF-8 without BOM                    | UTF-8 with BOM (bytes EF BB BF)            |
+
+### 10.1 Here-String Rule
+
+Here-strings are only safe in PS 5.1 if the closing `"@` is at column 1 (no leading whitespace).
+Preferred alternative - use string concatenation or the `-f` format operator inside functions:
+
+```powershell
+# Risky - indentation can break PS 5.1
+$query = @"
+    SELECT * FROM dbo.MyTable WHERE Id = $id
+"@
+
+# Safe
+$query = "SELECT * FROM dbo.MyTable WHERE Id = $id"
+
+# Safe multiline
+$query = "SELECT sl.ServerName, sl.InstanceName, " +
+         "ISNULL(si.NumberOfLogicalProcessors, 1) AS NumCores " +
+         "FROM Svr.ServerList sl " +
+         "LEFT JOIN Svr.ServerInfo si ON sl.ServerName = si.ServerName " +
+         "WHERE sl.Active = 1"
+```
+
+### 10.2 String Interpolation with Colons
+
+When a variable name is followed by a colon inside a double-quoted string, PowerShell misparses it as a scope qualifier. Use `$()` to disambiguate:
+
+```powershell
+# WRONG - PS misreads ${instance}: as a scope qualifier
+$msg = "Failed on ${instance}: $($_.Exception.Message)"
+
+# CORRECT
+$msg = "Failed on $($instance): $($_.Exception.Message)"
+# or
+$msg = "Failed on $instance - $($_.Exception.Message)"
+```
+
+---
+
+## 11. SQL Agent Configuration
+
+### 11.1 Job Step Settings
+
+- **Type:** CmdExec (not PowerShell - CmdExec provides correct exit code handling)
+- **Run As:** Proxy account (e.g., `DBA_Automation_Proxy`)
+- **Command template:**
+  ```
+  powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "\\path\script.ps1" -Param1 Value1
+  ```
+
+### 11.2 MSX/TSX Token Usage
+
+When deploying to MSX/TSX multi-server jobs, use tokens for the local server name:
+
+```
+-SqlInstance "$(ESCAPE_DQUOTE(SRVR))"
+```
+
+### 11.3 Exit Behavior
+
+- Scripts MUST `throw` on fatal failure - SQL Agent reads the exit code
+- Never swallow errors silently - a caught-and-suppressed error makes SQL Agent report SUCCESS
+- `exit 1` is acceptable but `throw` is preferred for error message visibility
+
+### 11.4 Required Flags
+
+- `-NoProfile` - faster startup, no profile interference
+- `-NonInteractive` - prevents hangs on prompts
+- `-Confirm:$false` in auto-invoke - suppresses ShouldProcess in non-interactive mode
+
+---
+
+## 12. Anti-Pattern Reference
+
+| Anti-Pattern                                                      | Correct Pattern                                    |
+|-------------------------------------------------------------------|----------------------------------------------------|
+| `. Write-Log.ps1`                                                 | Inline `Write-DbaLog` function in `begin` block    |
+| `$securePwd = $row.Password \| ConvertTo-SecureString -Force`    | `[PSCredential]$Credential` parameter              |
+| `$ErrorActionPreference = 'SilentlyContinue'`                    | Per-cmdlet `-ErrorAction SilentlyContinue`         |
+| `Set-ExecutionPolicy -Scope Process` inside script               | `-ExecutionPolicy Bypass` on command line          |
+| `Write-Output "Starting step 1"`                                  | `Write-DbaLog "Starting step 1"` (INFO -> Verbose) |
+| `Write-Host` anywhere                                             | Banned - use `Write-DbaLog`                        |
+| `Format-Table` / `ft`                                             | Return `[PSCustomObject]` to pipeline              |
+| String concatenation into SQL queries                             | `-SqlParameters @{ key = $val }`                   |
+| `Invoke-Expression`                                               | Direct cmdlet call                                 |
+
+---
+
+## 13. Quality Gate Checklist
+
+Before finalizing any script, verify every item:
+
+```
+STRUCTURE
+[ ] Dual-block pattern: script param() + function + auto-invoke
+[ ] CmdletBinding with SupportsShouldProcess and appropriate ConfirmImpact
+[ ] Complete comment-based help: .SYNOPSIS, .DESCRIPTION, .PARAMETER (each), .EXAMPLE (2+), .NOTES
+[ ] .NOTES includes Author, Created, Version, Requirements, Impact, Schedule, Permissions, SQL Agent Config
+[ ] Approved verb in function name (Invoke-, Get-, Set-, Test-, Enable-, Restore-, Install-)
+
+PARAMETERS
+[ ] All parameters have validation attributes
+[ ] SqlInstance uses [string[]] not [DbaInstanceParameter[]]
+[ ] PSCredential for SQL auth - no plaintext
+[ ] OutputPath with ValidateScript({ Test-Path $_ -PathType Container })
+[ ] RunLocally switch for CMS filtering
+[ ] CommandTimeout with ValidateRange
+[ ] IntroduceDelay / DelaySecMin / DelaySecMax if used in MSX/TSX jobs
+[ ] OutputFormat ValidateSet
+
+PS 5.1 COMPATIBILITY
+[ ] No ternary operators (?:)
+[ ] No null-coalescing (??) or null-conditional (?.)
+[ ] No pipeline chain operators (|| &&)
+[ ] No ForEach-Object -Parallel
+[ ] No $PSBoundParameters.Clone()
+[ ] No [DbaInstanceParameter] types
+[ ] No ::new() constructor (use New-Object or cast)
+[ ] No clean {} block
+[ ] Here-strings at column 1 or replaced with string concatenation
+[ ] No em dashes in strings or comments
+[ ] File saved as UTF-8 with BOM
+[ ] Variables followed by colon in strings use $() disambiguation
+
+SECURITY
+[ ] All SQL queries use SqlParameters - no string concatenation
+[ ] No Set-ExecutionPolicy calls inside script
+[ ] No plaintext credentials
+[ ] Required permissions documented in .NOTES
+
+ERROR HANDLING
+[ ] $ErrorActionPreference = 'Stop' in begin block
+[ ] Error accumulation via List[string] in process block
+[ ] Final throw for SQL Agent visibility
+[ ] CMS operations wrapped in try/catch with WARN - never throw
+[ ] Each instance processed independently with continue
+[ ] Write-DbaLog inline with ERROR/WARN/INFO/DEBUG levels
+[ ] Step name tracking ($stepName) updated before each major step
+
+DBATOOLS
+[ ] Module version check in begin block (separate "not installed" throw + "version low" warn)
+[ ] Import-Module with -MinimumVersion
+[ ] Invoke-DbaQuery with -EnableException and -SqlParameters
+[ ] Write-DbaDbTableData for bulk inserts
+[ ] No external Write-Log.ps1 / Out-DataTable.ps1 / SqlClient dependencies
+[ ] Credential splatting via $credParam = @{}
+
+OUTPUT
+[ ] Write-Output and Write-Host are absent
+[ ] Format-Table / ft is absent
+[ ] PSCustomObject results with PSTypeName added to pipeline
+[ ] OutputFormat parameter controls export (CSV / HTML / JSON / Excel / GridView)
+[ ] Results emitted to pipeline at end of end{} block
+[ ] Stopwatch started in begin, stopped and logged in end
+
+SQL AGENT
+[ ] Script throws (not exit 1) on fatal failure
+[ ] Auto-invoke filters Confirm and WhatIf from $PSBoundParameters
+[ ] Auto-invoke passes -Confirm:$false
+[ ] SQL Agent command uses -NoProfile -NonInteractive -ExecutionPolicy Bypass
+[ ] MSX/TSX jobs use $(ESCAPE_DQUOTE(SRVR)) token for server name
+```
+
+---
+
+## Appendix A: Approved dbatools Cmdlet Mapping
+
+| Operation                    | Approved Cmdlet                  |
+|------------------------------|----------------------------------|
+| Connect to instance          | `Connect-DbaInstance`            |
+| Run T-SQL query              | `Invoke-DbaQuery`                |
+| Bulk insert DataTable        | `Write-DbaDbTableData`           |
+| Get databases                | `Get-DbaDatabase`                |
+| Backup                       | `Backup-DbaDatabase`             |
+| Restore                      | `Restore-DbaDatabase`            |
+| Get SQL Agent jobs           | `Get-DbaAgentJob`                |
+| Create SQL Agent job         | `New-DbaAgentJob`                |
+| Get logins                   | `Get-DbaLogin`                   |
+| Add server role member       | `Add-DbaServerRoleMember`        |
+| Get AG info                  | `Get-DbaAvailabilityGroup`       |
+| Invoke AG failover           | `Invoke-DbaAgFailover`           |
+| Get instance info            | `Get-DbaInstanceProperty`        |
+| Copy database                | `Copy-DbaDatabase`               |
+
+---
+
+## Appendix B: Known Production Bug Patterns
+
+These are real bugs found during script modernization - check for these explicitly:
+
+| Bug                                             | Root Cause                                              | Fix                                           |
+|-------------------------------------------------|---------------------------------------------------------|-----------------------------------------------|
+| `Missing argument in parameter list`           | Variable followed by `:` in double-quoted string        | Use `$($var)` to disambiguate                |
+| SQL Agent job reports SUCCESS despite errors   | Error caught-and-swallowed in catch block               | Accumulate + throw in process block           |
+| Script hangs in SQL Agent but works manually   | Prompt being triggered (ShouldProcess or Read-Host)     | `-Confirm:$false` + `-NonInteractive`         |
+| CMS failure kills entire run                   | CMS write wrapped in throwing try/catch                 | WARN only on CMS operations                   |
+| Wrong instance targeted in MSX/TSX job        | Hardcoded server name in job step                       | Use `$(ESCAPE_DQUOTE(SRVR))` token            |
+| `No output` from SQL Agent CmdExec step       | Script-level param() block missing (only function def) | Add dual-block pattern                        |
+| Stored proc missing parameters                 | Auto-invoke not forwarding all $PSBoundParameters       | Audit param block parity between blocks       |


### PR DESCRIPTION
## Summary

Complete rewrite of the CentralDB PowerShell collection layer from legacy 2017-era raw SqlClient + dot-sourced helpers to dbatools v2+ following the new [powershell-dba-engineer-guidelines-v4.1.0.md](powershell-dba-engineer-guidelines-v4.1.0.md).

- 7 legacy `CentralDB/` scripts replaced by 7 modern `Collect/` scripts
- 5 external dot-sourced dependencies eliminated per script (`Write-Log.ps1`, `Out-DataTable.ps1`, `Write-DataTable.ps1`, `Get-DeployFile.ps1`, `Get-Type.ps1`)
- 3 new stored procedures encapsulating SQL logic previously embedded in PowerShell strings
- Full PS 5.1 compatibility, SQL Agent CmdExec dual-block pattern, CMS-driven fleet targeting

## Scripts replaced

| Legacy | New | Key changes |
|--------|-----|-------------|
| `CentralDB/Get-WaitStats.ps1` | `Collect/Get-CentralWaitStats.ps1` | `Get-DbaWaitStatistic` replaces hand-rolled CTE; `Write-DbaDbTableData` replaces `SqlBulkCopy` |
| `CentralDB/Get-Inventory.ps1` | `Collect/Get-CentralInventory.ps1` | All WMI replaced with dbatools; Linux support; `-Sections` parameter for partial runs |
| `CentralDB/Get-BaselineStats.ps1` | `Collect/Get-CentralBaselineStats.ps1` | Two-snapshot DMV logic moved into `Inst.usp_GetBaselineStats`; fixes buffer/proc cache % calculation bug |
| `CentralDB/Get-FRKBlitz.ps1` | `Collect/Invoke-CentralBlitzCollection.ps1` | `Install-DbaFirstResponderKit` replaces GO-splitter file parser; direct result set capture (no tempdb round-trip) |
| `CentralDB/Get-OlaHallengren-Backup.ps1` | `Collect/Invoke-CentralBackup.ps1` | `Install-DbaMaintenanceSolution` for deploy; encrypted backup support; AG-aware parameters |
| `CentralDB/Get-OlaHallengren-Index.ps1` | `Collect/Invoke-CentralIndexOptimize.ps1` | Fragmentation thresholds, UpdateStatistics, TimeLimit exposed as parameters |
| `CentralDB/Get-OlaHallengren-Integrity.ps1` | `Collect/Invoke-CentralIntegrityCheck.ps1` | CheckCommands ValidateSet; PhysicalOnly default Y; DatabasesInParallel support |

## New stored procedures

| Object | Purpose |
|--------|---------|
| `Svr.usp_GetCollectionTargets` | Centralizes instance discovery — replaces inline `SELECT` from `[Svr].[ServerList]` embedded in each script |
| `Svr.usp_SetCollectionLastRun` | Records last successful run timestamp per instance per collection type |
| `Inst.usp_GetBaselineStats` | Two-snapshot `sys.dm_os_performance_counters` PIVOT; fixes legacy cache % calculation |

## Architecture changes (all scripts)

- **Dual-block pattern** — script `param()` + function + auto-invoke for SQL Agent CmdExec compatibility
- **CMS-driven targeting** — `Svr.usp_GetCollectionTargets` replaces ad-hoc inline queries; `RunLocally` switch for MSX/TSX jobs
- **Error accumulation** — one instance failure is logged and skipped; remaining instances continue; accumulated errors thrown at end so SQL Agent sees FAILURE
- **CMS operations non-fatal** — CentralDB write failures WARN and continue; a CMS outage never aborts collection
- **`LoadGUID` correlation** — auto-generated GUID threads through collection, CommandLog query, centralization, and cleanup for end-to-end traceability
- **No external dependencies** — inline `Write-DbaLog` replaces dot-sourced `Write-Log.ps1`; `Write-DbaDbTableData` replaces Chad Miller helpers

## Documentation

- `README.md` — full rewrite: architecture diagram, quick-start, per-script reference, SQL Agent templates, SSRS catalogue
- `CentralDB-Ops-Runbook.md` — new: deployment steps, per-script job command templates, recommended schedule, add/remove instance procedures, troubleshooting guide

## Test plan

- [ ] Deploy stored procedures against a test CentralDB instance
- [ ] Run each `Collect/` script manually with `-Verbose` against a test SQL Server
- [ ] Verify rows appear in the expected CentralDB tables
- [ ] Verify CSV output written to `-OutputPath`
- [ ] Run with `-WhatIf` on the three `Invoke-` scripts and confirm no changes made
- [ ] Run `Get-CentralInventory.ps1 -Sections ServerOS` against a Linux SQL Server instance and confirm graceful skip
- [ ] Simulate CMS unavailable (wrong `-CMSInstanceName`) — confirm script completes with WARN, not failure
- [ ] Create SQL Agent CmdExec jobs using the templates in `CentralDB-Ops-Runbook.md` and verify correct exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)